### PR TITLE
feat: Issue CRUD backend services

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
 		<PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
 		<PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.2" />
 		<PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.2" />
 

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="MongoDB.Bson" />
   </ItemGroup>
 

--- a/src/Domain/DomainMarker.cs
+++ b/src/Domain/DomainMarker.cs
@@ -1,0 +1,15 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     DomainMarker.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+namespace Domain;
+
+/// <summary>
+///   Marker class used for MediatR assembly scanning registration.
+/// </summary>
+public sealed class DomainMarker;

--- a/src/Domain/Features/Issues/Commands/ChangeIssueStatusCommand.cs
+++ b/src/Domain/Features/Issues/Commands/ChangeIssueStatusCommand.cs
@@ -1,0 +1,71 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     ChangeIssueStatusCommand.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Abstractions;
+
+namespace Domain.Features.Issues.Commands;
+
+/// <summary>
+///   Command to change the status of an issue.
+/// </summary>
+public record ChangeIssueStatusCommand(
+	string Id,
+	StatusDto NewStatus) : IRequest<Result<IssueDto>>;
+
+/// <summary>
+///   Handler for changing the status of an issue.
+/// </summary>
+public sealed class ChangeIssueStatusCommandHandler : IRequestHandler<ChangeIssueStatusCommand, Result<IssueDto>>
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly ILogger<ChangeIssueStatusCommandHandler> _logger;
+
+	public ChangeIssueStatusCommandHandler(
+		IRepository<Issue> repository,
+		ILogger<ChangeIssueStatusCommandHandler> logger)
+	{
+		_repository = repository;
+		_logger = logger;
+	}
+
+	public async Task<Result<IssueDto>> Handle(ChangeIssueStatusCommand request, CancellationToken cancellationToken)
+	{
+		_logger.LogInformation(
+			"Changing status of issue {IssueId} to {NewStatus}",
+			request.Id,
+			request.NewStatus.StatusName);
+
+		var existingResult = await _repository.GetByIdAsync(request.Id, cancellationToken);
+
+		if (existingResult.Failure || existingResult.Value is null)
+		{
+			_logger.LogWarning("Issue not found with ID: {IssueId}", request.Id);
+			return Result.Fail<IssueDto>("Issue not found", ResultErrorCode.NotFound);
+		}
+
+		var issue = existingResult.Value;
+		issue.Status = request.NewStatus;
+		issue.DateModified = DateTime.UtcNow;
+
+		var result = await _repository.UpdateAsync(issue, cancellationToken);
+
+		if (result.Failure)
+		{
+			_logger.LogError("Failed to change issue status: {Error}", result.Error);
+			return Result.Fail<IssueDto>(result.Error ?? "Failed to change issue status", result.ErrorCode);
+		}
+
+		_logger.LogInformation(
+			"Successfully changed status of issue {IssueId} to {NewStatus}",
+			request.Id,
+			request.NewStatus.StatusName);
+
+		return Result.Ok(new IssueDto(result.Value!));
+	}
+}

--- a/src/Domain/Features/Issues/Commands/CreateIssueCommand.cs
+++ b/src/Domain/Features/Issues/Commands/CreateIssueCommand.cs
@@ -1,0 +1,75 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     CreateIssueCommand.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Abstractions;
+
+namespace Domain.Features.Issues.Commands;
+
+/// <summary>
+///   Command to create a new issue.
+/// </summary>
+public record CreateIssueCommand(
+	string Title,
+	string Description,
+	CategoryDto Category,
+	UserDto Author) : IRequest<Result<IssueDto>>;
+
+/// <summary>
+///   Handler for creating a new issue.
+/// </summary>
+public sealed class CreateIssueCommandHandler : IRequestHandler<CreateIssueCommand, Result<IssueDto>>
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly ILogger<CreateIssueCommandHandler> _logger;
+
+	public CreateIssueCommandHandler(
+		IRepository<Issue> repository,
+		ILogger<CreateIssueCommandHandler> logger)
+	{
+		_repository = repository;
+		_logger = logger;
+	}
+
+	public async Task<Result<IssueDto>> Handle(CreateIssueCommand request, CancellationToken cancellationToken)
+	{
+		_logger.LogInformation("Creating new issue with title: {Title}", request.Title);
+
+		var issue = new Issue
+		{
+			Id = ObjectId.GenerateNewId(),
+			Title = request.Title,
+			Description = request.Description,
+			Category = request.Category,
+			Author = request.Author,
+			Status = new StatusDto(
+				ObjectId.Empty,
+				"Open",
+				"Issue is open and awaiting review",
+				DateTime.UtcNow,
+				null,
+				false,
+				UserDto.Empty),
+			DateCreated = DateTime.UtcNow,
+			ApprovedForRelease = false,
+			Archived = false,
+			Rejected = false
+		};
+
+		var result = await _repository.AddAsync(issue, cancellationToken);
+
+		if (result.Failure)
+		{
+			_logger.LogError("Failed to create issue: {Error}", result.Error);
+			return Result.Fail<IssueDto>(result.Error ?? "Failed to create issue", result.ErrorCode);
+		}
+
+		_logger.LogInformation("Successfully created issue with ID: {IssueId}", issue.Id);
+		return Result.Ok(new IssueDto(result.Value!));
+	}
+}

--- a/src/Domain/Features/Issues/Commands/DeleteIssueCommand.cs
+++ b/src/Domain/Features/Issues/Commands/DeleteIssueCommand.cs
@@ -1,0 +1,65 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     DeleteIssueCommand.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Abstractions;
+
+namespace Domain.Features.Issues.Commands;
+
+/// <summary>
+///   Command to soft delete (archive) an issue.
+/// </summary>
+public record DeleteIssueCommand(
+	string Id,
+	UserDto ArchivedBy) : IRequest<Result<bool>>;
+
+/// <summary>
+///   Handler for soft deleting (archiving) an issue.
+/// </summary>
+public sealed class DeleteIssueCommandHandler : IRequestHandler<DeleteIssueCommand, Result<bool>>
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly ILogger<DeleteIssueCommandHandler> _logger;
+
+	public DeleteIssueCommandHandler(
+		IRepository<Issue> repository,
+		ILogger<DeleteIssueCommandHandler> logger)
+	{
+		_repository = repository;
+		_logger = logger;
+	}
+
+	public async Task<Result<bool>> Handle(DeleteIssueCommand request, CancellationToken cancellationToken)
+	{
+		_logger.LogInformation("Archiving issue with ID: {IssueId}", request.Id);
+
+		var existingResult = await _repository.GetByIdAsync(request.Id, cancellationToken);
+
+		if (existingResult.Failure || existingResult.Value is null)
+		{
+			_logger.LogWarning("Issue not found with ID: {IssueId}", request.Id);
+			return Result.Fail<bool>("Issue not found", ResultErrorCode.NotFound);
+		}
+
+		var issue = existingResult.Value;
+		issue.Archived = true;
+		issue.ArchivedBy = request.ArchivedBy;
+		issue.DateModified = DateTime.UtcNow;
+
+		var result = await _repository.UpdateAsync(issue, cancellationToken);
+
+		if (result.Failure)
+		{
+			_logger.LogError("Failed to archive issue: {Error}", result.Error);
+			return Result.Fail<bool>(result.Error ?? "Failed to archive issue", result.ErrorCode);
+		}
+
+		_logger.LogInformation("Successfully archived issue with ID: {IssueId}", request.Id);
+		return Result.Ok(true);
+	}
+}

--- a/src/Domain/Features/Issues/Commands/UpdateIssueCommand.cs
+++ b/src/Domain/Features/Issues/Commands/UpdateIssueCommand.cs
@@ -1,0 +1,68 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     UpdateIssueCommand.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Abstractions;
+
+namespace Domain.Features.Issues.Commands;
+
+/// <summary>
+///   Command to update an existing issue.
+/// </summary>
+public record UpdateIssueCommand(
+	string Id,
+	string Title,
+	string Description,
+	CategoryDto Category) : IRequest<Result<IssueDto>>;
+
+/// <summary>
+///   Handler for updating an existing issue.
+/// </summary>
+public sealed class UpdateIssueCommandHandler : IRequestHandler<UpdateIssueCommand, Result<IssueDto>>
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly ILogger<UpdateIssueCommandHandler> _logger;
+
+	public UpdateIssueCommandHandler(
+		IRepository<Issue> repository,
+		ILogger<UpdateIssueCommandHandler> logger)
+	{
+		_repository = repository;
+		_logger = logger;
+	}
+
+	public async Task<Result<IssueDto>> Handle(UpdateIssueCommand request, CancellationToken cancellationToken)
+	{
+		_logger.LogInformation("Updating issue with ID: {IssueId}", request.Id);
+
+		var existingResult = await _repository.GetByIdAsync(request.Id, cancellationToken);
+
+		if (existingResult.Failure || existingResult.Value is null)
+		{
+			_logger.LogWarning("Issue not found with ID: {IssueId}", request.Id);
+			return Result.Fail<IssueDto>("Issue not found", ResultErrorCode.NotFound);
+		}
+
+		var issue = existingResult.Value;
+		issue.Title = request.Title;
+		issue.Description = request.Description;
+		issue.Category = request.Category;
+		issue.DateModified = DateTime.UtcNow;
+
+		var result = await _repository.UpdateAsync(issue, cancellationToken);
+
+		if (result.Failure)
+		{
+			_logger.LogError("Failed to update issue: {Error}", result.Error);
+			return Result.Fail<IssueDto>(result.Error ?? "Failed to update issue", result.ErrorCode);
+		}
+
+		_logger.LogInformation("Successfully updated issue with ID: {IssueId}", request.Id);
+		return Result.Ok(new IssueDto(result.Value!));
+	}
+}

--- a/src/Domain/Features/Issues/Queries/GetIssueByIdQuery.cs
+++ b/src/Domain/Features/Issues/Queries/GetIssueByIdQuery.cs
@@ -1,0 +1,50 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GetIssueByIdQuery.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Abstractions;
+
+namespace Domain.Features.Issues.Queries;
+
+/// <summary>
+///   Query to get a single issue by ID.
+/// </summary>
+public record GetIssueByIdQuery(string Id) : IRequest<Result<IssueDto>>;
+
+/// <summary>
+///   Handler for getting a single issue by ID.
+/// </summary>
+public sealed class GetIssueByIdQueryHandler : IRequestHandler<GetIssueByIdQuery, Result<IssueDto>>
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly ILogger<GetIssueByIdQueryHandler> _logger;
+
+	public GetIssueByIdQueryHandler(
+		IRepository<Issue> repository,
+		ILogger<GetIssueByIdQueryHandler> logger)
+	{
+		_repository = repository;
+		_logger = logger;
+	}
+
+	public async Task<Result<IssueDto>> Handle(GetIssueByIdQuery request, CancellationToken cancellationToken)
+	{
+		_logger.LogInformation("Fetching issue with ID: {IssueId}", request.Id);
+
+		var result = await _repository.GetByIdAsync(request.Id, cancellationToken);
+
+		if (result.Failure || result.Value is null)
+		{
+			_logger.LogWarning("Issue not found with ID: {IssueId}", request.Id);
+			return Result.Fail<IssueDto>("Issue not found", ResultErrorCode.NotFound);
+		}
+
+		_logger.LogInformation("Successfully fetched issue with ID: {IssueId}", request.Id);
+		return Result.Ok(new IssueDto(result.Value));
+	}
+}

--- a/src/Domain/Features/Issues/Queries/GetIssuesQuery.cs
+++ b/src/Domain/Features/Issues/Queries/GetIssuesQuery.cs
@@ -1,0 +1,106 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GetIssuesQuery.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Abstractions;
+
+namespace Domain.Features.Issues.Queries;
+
+/// <summary>
+///   Query to get a paginated list of issues with optional filters.
+/// </summary>
+public record GetIssuesQuery(
+	int Page = 1,
+	int PageSize = 10,
+	string? StatusFilter = null,
+	string? CategoryFilter = null,
+	bool IncludeArchived = false) : IRequest<Result<PaginatedResponse<IssueDto>>>;
+
+/// <summary>
+///   Handler for getting a paginated list of issues.
+/// </summary>
+public sealed class GetIssuesQueryHandler : IRequestHandler<GetIssuesQuery, Result<PaginatedResponse<IssueDto>>>
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly ILogger<GetIssuesQueryHandler> _logger;
+
+	public GetIssuesQueryHandler(
+		IRepository<Issue> repository,
+		ILogger<GetIssuesQueryHandler> logger)
+	{
+		_repository = repository;
+		_logger = logger;
+	}
+
+	public async Task<Result<PaginatedResponse<IssueDto>>> Handle(
+		GetIssuesQuery request,
+		CancellationToken cancellationToken)
+	{
+		_logger.LogInformation(
+			"Fetching issues - Page: {Page}, PageSize: {PageSize}, Status: {Status}, Category: {Category}",
+			request.Page,
+			request.PageSize,
+			request.StatusFilter ?? "All",
+			request.CategoryFilter ?? "All");
+
+		var allResult = await _repository.GetAllAsync(cancellationToken);
+
+		if (allResult.Failure)
+		{
+			_logger.LogError("Failed to fetch issues: {Error}", allResult.Error);
+			return Result.Fail<PaginatedResponse<IssueDto>>(
+				allResult.Error ?? "Failed to fetch issues",
+				allResult.ErrorCode);
+		}
+
+		var issues = allResult.Value?.ToList() ?? [];
+
+		// Apply filters
+		if (!request.IncludeArchived)
+		{
+			issues = issues.Where(i => !i.Archived).ToList();
+		}
+
+		if (!string.IsNullOrWhiteSpace(request.StatusFilter))
+		{
+			issues = issues
+				.Where(i => i.Status.StatusName.Equals(request.StatusFilter, StringComparison.OrdinalIgnoreCase))
+				.ToList();
+		}
+
+		if (!string.IsNullOrWhiteSpace(request.CategoryFilter))
+		{
+			issues = issues
+				.Where(i => i.Category.CategoryName.Equals(request.CategoryFilter, StringComparison.OrdinalIgnoreCase))
+				.ToList();
+		}
+
+		var total = issues.Count;
+
+		// Apply pagination
+		var pagedIssues = issues
+			.OrderByDescending(i => i.DateCreated)
+			.Skip((request.Page - 1) * request.PageSize)
+			.Take(request.PageSize)
+			.Select(i => new IssueDto(i))
+			.ToList();
+
+		var response = new PaginatedResponse<IssueDto>(
+			pagedIssues,
+			total,
+			request.Page,
+			request.PageSize);
+
+		_logger.LogInformation(
+			"Successfully fetched {Count} issues out of {Total}",
+			pagedIssues.Count,
+			total);
+
+		return Result.Ok(response);
+	}
+}

--- a/src/Domain/Features/Issues/Validators/CreateIssueCommandValidator.cs
+++ b/src/Domain/Features/Issues/Validators/CreateIssueCommandValidator.cs
@@ -1,0 +1,60 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     CreateIssueCommandValidator.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Features.Issues.Commands;
+
+namespace Domain.Features.Issues.Validators;
+
+/// <summary>
+///   Validator for CreateIssueCommand.
+/// </summary>
+public sealed class CreateIssueCommandValidator : AbstractValidator<CreateIssueCommand>
+{
+	public CreateIssueCommandValidator()
+	{
+		RuleFor(x => x.Title)
+			.NotEmpty()
+			.WithMessage("Title is required")
+			.MaximumLength(200)
+			.WithMessage("Title must not exceed 200 characters")
+			.MinimumLength(5)
+			.WithMessage("Title must be at least 5 characters");
+
+		RuleFor(x => x.Description)
+			.NotEmpty()
+			.WithMessage("Description is required")
+			.MaximumLength(5000)
+			.WithMessage("Description must not exceed 5000 characters")
+			.MinimumLength(10)
+			.WithMessage("Description must be at least 10 characters");
+
+		RuleFor(x => x.Category)
+			.NotNull()
+			.WithMessage("Category is required");
+
+		RuleFor(x => x.Category.CategoryName)
+			.NotEmpty()
+			.WithMessage("Category name is required")
+			.When(x => x.Category is not null);
+
+		RuleFor(x => x.Author)
+			.NotNull()
+			.WithMessage("Author is required");
+
+		RuleFor(x => x.Author.Id)
+			.NotEmpty()
+			.WithMessage("Author ID is required")
+			.When(x => x.Author is not null);
+
+		RuleFor(x => x.Author.Name)
+			.NotEmpty()
+			.WithMessage("Author name is required")
+			.When(x => x.Author is not null);
+	}
+}

--- a/src/Domain/Features/Issues/Validators/UpdateIssueCommandValidator.cs
+++ b/src/Domain/Features/Issues/Validators/UpdateIssueCommandValidator.cs
@@ -1,0 +1,57 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     UpdateIssueCommandValidator.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain
+// =======================================================
+
+using Domain.Features.Issues.Commands;
+
+namespace Domain.Features.Issues.Validators;
+
+/// <summary>
+///   Validator for UpdateIssueCommand.
+/// </summary>
+public sealed class UpdateIssueCommandValidator : AbstractValidator<UpdateIssueCommand>
+{
+	public UpdateIssueCommandValidator()
+	{
+		RuleFor(x => x.Id)
+			.NotEmpty()
+			.WithMessage("Issue ID is required")
+			.Must(BeValidObjectId)
+			.WithMessage("Issue ID must be a valid ObjectId");
+
+		RuleFor(x => x.Title)
+			.NotEmpty()
+			.WithMessage("Title is required")
+			.MaximumLength(200)
+			.WithMessage("Title must not exceed 200 characters")
+			.MinimumLength(5)
+			.WithMessage("Title must be at least 5 characters");
+
+		RuleFor(x => x.Description)
+			.NotEmpty()
+			.WithMessage("Description is required")
+			.MaximumLength(5000)
+			.WithMessage("Description must not exceed 5000 characters")
+			.MinimumLength(10)
+			.WithMessage("Description must be at least 10 characters");
+
+		RuleFor(x => x.Category)
+			.NotNull()
+			.WithMessage("Category is required");
+
+		RuleFor(x => x.Category.CategoryName)
+			.NotEmpty()
+			.WithMessage("Category name is required")
+			.When(x => x.Category is not null);
+	}
+
+	private static bool BeValidObjectId(string id)
+	{
+		return ObjectId.TryParse(id, out _);
+	}
+}

--- a/src/Domain/GlobalUsings.cs
+++ b/src/Domain/GlobalUsings.cs
@@ -26,6 +26,9 @@ global using MediatR;
 // FluentValidation
 global using FluentValidation;
 
+// Microsoft Extensions
+global using Microsoft.Extensions.Logging;
+
 // Domain
 global using Domain.DTOs;
 global using Domain.Models;

--- a/src/Web/Data/DataSeeder.cs
+++ b/src/Web/Data/DataSeeder.cs
@@ -1,0 +1,211 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     DataSeeder.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Web
+// =======================================================
+
+using Domain.Abstractions;
+using Domain.DTOs;
+using Domain.Models;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+
+namespace Web.Data;
+
+/// <summary>
+///   Service for seeding default data into the database.
+/// </summary>
+public interface IDataSeeder
+{
+	/// <summary>
+	///   Seeds default categories and statuses if they don't exist.
+	/// </summary>
+	Task SeedAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   Implementation of IDataSeeder.
+/// </summary>
+public sealed class DataSeeder : IDataSeeder
+{
+	private readonly IRepository<Category> _categoryRepository;
+	private readonly IRepository<Status> _statusRepository;
+	private readonly ILogger<DataSeeder> _logger;
+
+	public DataSeeder(
+		IRepository<Category> categoryRepository,
+		IRepository<Status> statusRepository,
+		ILogger<DataSeeder> logger)
+	{
+		_categoryRepository = categoryRepository;
+		_statusRepository = statusRepository;
+		_logger = logger;
+	}
+
+	public async Task SeedAsync(CancellationToken cancellationToken = default)
+	{
+		await SeedCategoriesAsync(cancellationToken);
+		await SeedStatusesAsync(cancellationToken);
+	}
+
+	private async Task SeedCategoriesAsync(CancellationToken cancellationToken)
+	{
+		var existingCategories = await _categoryRepository.GetAllAsync(cancellationToken);
+
+		if (existingCategories.Success && existingCategories.Value?.Any() == true)
+		{
+			_logger.LogInformation("Categories already seeded, skipping...");
+			return;
+		}
+
+		_logger.LogInformation("Seeding default categories...");
+
+		var defaultCategories = new List<Category>
+		{
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				CategoryName = "Bug",
+				CategoryDescription = "Something isn't working as expected",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				CategoryName = "Feature",
+				CategoryDescription = "New feature or request",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				CategoryName = "Enhancement",
+				CategoryDescription = "Improvement to existing functionality",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				CategoryName = "Question",
+				CategoryDescription = "Further information is requested",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				CategoryName = "Documentation",
+				CategoryDescription = "Improvements or additions to documentation",
+				DateCreated = DateTime.UtcNow
+			}
+		};
+
+		var result = await _categoryRepository.AddRangeAsync(defaultCategories, cancellationToken);
+
+		if (result.Success)
+		{
+			_logger.LogInformation("Successfully seeded {Count} categories", defaultCategories.Count);
+		}
+		else
+		{
+			_logger.LogError("Failed to seed categories: {Error}", result.Error);
+		}
+	}
+
+	private async Task SeedStatusesAsync(CancellationToken cancellationToken)
+	{
+		var existingStatuses = await _statusRepository.GetAllAsync(cancellationToken);
+
+		if (existingStatuses.Success && existingStatuses.Value?.Any() == true)
+		{
+			_logger.LogInformation("Statuses already seeded, skipping...");
+			return;
+		}
+
+		_logger.LogInformation("Seeding default statuses...");
+
+		var defaultStatuses = new List<Status>
+		{
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				StatusName = "Open",
+				StatusDescription = "Issue is open and awaiting review",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				StatusName = "In Progress",
+				StatusDescription = "Issue is currently being worked on",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				StatusName = "Under Review",
+				StatusDescription = "Issue is under review",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				StatusName = "Resolved",
+				StatusDescription = "Issue has been resolved",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				StatusName = "Closed",
+				StatusDescription = "Issue has been closed",
+				DateCreated = DateTime.UtcNow
+			},
+			new()
+			{
+				Id = ObjectId.GenerateNewId(),
+				StatusName = "Won't Fix",
+				StatusDescription = "Issue will not be addressed",
+				DateCreated = DateTime.UtcNow
+			}
+		};
+
+		var result = await _statusRepository.AddRangeAsync(defaultStatuses, cancellationToken);
+
+		if (result.Success)
+		{
+			_logger.LogInformation("Successfully seeded {Count} statuses", defaultStatuses.Count);
+		}
+		else
+		{
+			_logger.LogError("Failed to seed statuses: {Error}", result.Error);
+		}
+	}
+}
+
+/// <summary>
+///   Extension methods for registering the DataSeeder.
+/// </summary>
+public static class DataSeederExtensions
+{
+	/// <summary>
+	///   Adds the DataSeeder to the service collection.
+	/// </summary>
+	public static IServiceCollection AddDataSeeder(this IServiceCollection services)
+	{
+		services.AddScoped<IDataSeeder, DataSeeder>();
+		return services;
+	}
+
+	/// <summary>
+	///   Seeds the default data.
+	/// </summary>
+	public static async Task SeedDataAsync(this IServiceProvider serviceProvider)
+	{
+		using var scope = serviceProvider.CreateScope();
+		var seeder = scope.ServiceProvider.GetRequiredService<IDataSeeder>();
+		await seeder.SeedAsync();
+	}
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -1,9 +1,13 @@
 using Auth0.AspNetCore.Authentication;
+using Domain;
+using FluentValidation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Persistence.MongoDb;
 using Web.Auth;
 using Web.Components;
+using Web.Data;
+using Web.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +19,18 @@ builder.Services.AddMongoDbPersistence(builder.Configuration);
 
 // Add MongoDB connection from Aspire service discovery
 builder.AddMongoDBClient("mongodb");
+
+// Add MediatR for CQRS pattern
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(DomainMarker).Assembly));
+
+// Add FluentValidation validators
+builder.Services.AddValidatorsFromAssembly(typeof(DomainMarker).Assembly);
+
+// Add application services
+builder.Services.AddScoped<IIssueService, IssueService>();
+
+// Add data seeder
+builder.Services.AddDataSeeder();
 
 // Configure Auth0 authentication
 var auth0Options = builder.Configuration.GetSection("Auth0").Get<Auth0Options>()
@@ -53,6 +69,9 @@ var app = builder.Build();
 if (!app.Environment.IsEnvironment("Testing"))
 {
 	await app.Services.InitializeMongoDbAsync();
+
+	// Seed default data
+	await app.Services.SeedDataAsync();
 }
 
 // Map health check endpoints (development only by default)

--- a/src/Web/Services/IssueService.cs
+++ b/src/Web/Services/IssueService.cs
@@ -1,0 +1,145 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     IssueService.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Web
+// =======================================================
+
+using Domain.Abstractions;
+using Domain.DTOs;
+using Domain.Features.Issues.Commands;
+using Domain.Features.Issues.Queries;
+using MediatR;
+
+namespace Web.Services;
+
+/// <summary>
+///   Service facade for Issue CRUD operations, wrapping MediatR calls.
+/// </summary>
+public interface IIssueService
+{
+	/// <summary>
+	///   Gets a paginated list of issues with optional filters.
+	/// </summary>
+	Task<Result<PaginatedResponse<IssueDto>>> GetIssuesAsync(
+		int page = 1,
+		int pageSize = 10,
+		string? statusFilter = null,
+		string? categoryFilter = null,
+		bool includeArchived = false,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	///   Gets a single issue by ID.
+	/// </summary>
+	Task<Result<IssueDto>> GetIssueByIdAsync(string id, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	///   Creates a new issue.
+	/// </summary>
+	Task<Result<IssueDto>> CreateIssueAsync(
+		string title,
+		string description,
+		CategoryDto category,
+		UserDto author,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	///   Updates an existing issue.
+	/// </summary>
+	Task<Result<IssueDto>> UpdateIssueAsync(
+		string id,
+		string title,
+		string description,
+		CategoryDto category,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	///   Soft deletes (archives) an issue.
+	/// </summary>
+	Task<Result<bool>> DeleteIssueAsync(
+		string id,
+		UserDto archivedBy,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	///   Changes the status of an issue.
+	/// </summary>
+	Task<Result<IssueDto>> ChangeIssueStatusAsync(
+		string id,
+		StatusDto newStatus,
+		CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   Implementation of IIssueService using MediatR.
+/// </summary>
+public sealed class IssueService : IIssueService
+{
+	private readonly IMediator _mediator;
+
+	public IssueService(IMediator mediator)
+	{
+		_mediator = mediator;
+	}
+
+	public async Task<Result<PaginatedResponse<IssueDto>>> GetIssuesAsync(
+		int page = 1,
+		int pageSize = 10,
+		string? statusFilter = null,
+		string? categoryFilter = null,
+		bool includeArchived = false,
+		CancellationToken cancellationToken = default)
+	{
+		var query = new GetIssuesQuery(page, pageSize, statusFilter, categoryFilter, includeArchived);
+		return await _mediator.Send(query, cancellationToken);
+	}
+
+	public async Task<Result<IssueDto>> GetIssueByIdAsync(string id, CancellationToken cancellationToken = default)
+	{
+		var query = new GetIssueByIdQuery(id);
+		return await _mediator.Send(query, cancellationToken);
+	}
+
+	public async Task<Result<IssueDto>> CreateIssueAsync(
+		string title,
+		string description,
+		CategoryDto category,
+		UserDto author,
+		CancellationToken cancellationToken = default)
+	{
+		var command = new CreateIssueCommand(title, description, category, author);
+		return await _mediator.Send(command, cancellationToken);
+	}
+
+	public async Task<Result<IssueDto>> UpdateIssueAsync(
+		string id,
+		string title,
+		string description,
+		CategoryDto category,
+		CancellationToken cancellationToken = default)
+	{
+		var command = new UpdateIssueCommand(id, title, description, category);
+		return await _mediator.Send(command, cancellationToken);
+	}
+
+	public async Task<Result<bool>> DeleteIssueAsync(
+		string id,
+		UserDto archivedBy,
+		CancellationToken cancellationToken = default)
+	{
+		var command = new DeleteIssueCommand(id, archivedBy);
+		return await _mediator.Send(command, cancellationToken);
+	}
+
+	public async Task<Result<IssueDto>> ChangeIssueStatusAsync(
+		string id,
+		StatusDto newStatus,
+		CancellationToken cancellationToken = default)
+	{
+		var command = new ChangeIssueStatusCommand(id, newStatus);
+		return await _mediator.Send(command, cancellationToken);
+	}
+}


### PR DESCRIPTION
## Summary

Implements backend services for Issue CRUD operations using MediatR CQRS pattern.

Part of #22

## Changes

### Commands
- **CreateIssueCommand** - Creates new issues with default 'Open' status
- **UpdateIssueCommand** - Updates issue title, description, and category
- **DeleteIssueCommand** - Soft deletes (archives) issues
- **ChangeIssueStatusCommand** - Changes issue status

### Queries
- **GetIssuesQuery** - Paginated list with optional filters (status, category, archived)
- **GetIssueByIdQuery** - Gets single issue by ID

### Validators (FluentValidation)
- **CreateIssueCommandValidator** - Validates title (5-200 chars), description (10-5000 chars), category, author
- **UpdateIssueCommandValidator** - Validates ID (valid ObjectId), title, description, category

### Services
- **IssueService** - Facade service wrapping MediatR calls for Blazor components
- **DataSeeder** - Seeds default categories and statuses

### Default Seed Data
**Categories:** Bug, Feature, Enhancement, Question, Documentation
**Statuses:** Open, In Progress, Under Review, Resolved, Closed, Won't Fix

## Testing
- Build succeeds
- No breaking changes

## Next Steps
UI implementation will be done in a separate PR to complete #22