### PR TITLE
chore: Remove copyright headers from .razor files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,6 +48,9 @@ tab_width = 2
 [*.razor]
 indent_style = tab
 indent_size = 2
+# NOTE: Razor files should NOT have file headers/copyright comments.
+# Copyright headers are only required in *.cs files.
+file_header_template = unset
 
 ########################################
 # C# / .NET rules

--- a/src/Web/Components/Charts/BarChart.razor
+++ b/src/Web/Components/Charts/BarChart.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     BarChart.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @implements IAsyncDisposable
 @inject IJSRuntime JSRuntime
 

--- a/src/Web/Components/Charts/LineChart.razor
+++ b/src/Web/Components/Charts/LineChart.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     LineChart.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @implements IAsyncDisposable
 @inject IJSRuntime JSRuntime
 

--- a/src/Web/Components/Charts/PieChart.razor
+++ b/src/Web/Components/Charts/PieChart.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     PieChart.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @implements IAsyncDisposable
 @inject IJSRuntime JSRuntime
 

--- a/src/Web/Components/Issues/AttachmentCard.razor
+++ b/src/Web/Components/Issues/AttachmentCard.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     AttachmentCard.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Domain.DTOs
 
 <div class="group relative bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-md transition-shadow duration-200">

--- a/src/Web/Components/Issues/AttachmentList.razor
+++ b/src/Web/Components/Issues/AttachmentList.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     AttachmentList.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Domain.DTOs
 @using Web.Components.Shared
 

--- a/src/Web/Components/Issues/BulkActionToolbar.razor
+++ b/src/Web/Components/Issues/BulkActionToolbar.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     BulkActionToolbar.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Web.Services
 @using Domain.DTOs
 @implements IDisposable

--- a/src/Web/Components/Issues/BulkConfirmationModal.razor
+++ b/src/Web/Components/Issues/BulkConfirmationModal.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     BulkConfirmationModal.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @* Modal dialog for confirming destructive bulk operations *@
 
 @if (IsVisible)

--- a/src/Web/Components/Issues/BulkProgressIndicator.razor
+++ b/src/Web/Components/Issues/BulkProgressIndicator.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     BulkProgressIndicator.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Web.Services
 
 @* Progress indicator for bulk operations showing real-time progress *@

--- a/src/Web/Components/Issues/CommentsSection.razor
+++ b/src/Web/Components/Issues/CommentsSection.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     CommentsSection.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Microsoft.AspNetCore.Components.Authorization
 @using Web.Auth
 @using Web.Services

--- a/src/Web/Components/Issues/IssueMultiSelect.razor
+++ b/src/Web/Components/Issues/IssueMultiSelect.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     IssueMultiSelect.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Web.Services
 @implements IDisposable
 @inject BulkSelectionState SelectionState

--- a/src/Web/Components/Issues/UndoToast.razor
+++ b/src/Web/Components/Issues/UndoToast.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     UndoToast.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @implements IDisposable
 
 @* Toast notification with undo functionality and countdown timer *@

--- a/src/Web/Components/Pages/Admin/AdminPageLayout.razor
+++ b/src/Web/Components/Pages/Admin/AdminPageLayout.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     AdminPageLayout.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 <div class="min-h-screen bg-gray-50 dark:bg-gray-900">
 	<!-- Admin Navigation Bar -->
 	<nav class="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">

--- a/src/Web/Components/Pages/Admin/Analytics.razor
+++ b/src/Web/Components/Pages/Admin/Analytics.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Analytics.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/admin/analytics"
 @attribute [Authorize(Policy = "AdminPolicy")]
 @layout AdminPageLayout

--- a/src/Web/Components/Pages/Admin/Categories.razor
+++ b/src/Web/Components/Pages/Admin/Categories.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Categories.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/admin/categories"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Web/Components/Pages/Admin/Statuses.razor
+++ b/src/Web/Components/Pages/Admin/Statuses.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Statuses.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/admin/statuses"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Web/Components/Pages/Dashboard.razor
+++ b/src/Web/Components/Pages/Dashboard.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Dashboard.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/dashboard"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Web/Components/Pages/Issues/Create.razor
+++ b/src/Web/Components/Pages/Issues/Create.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Create.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/issues/create"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Web/Components/Pages/Issues/Details.razor
+++ b/src/Web/Components/Pages/Issues/Details.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Details.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/issues/{Id}"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Web/Components/Pages/Issues/Edit.razor
+++ b/src/Web/Components/Pages/Issues/Edit.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Edit.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/issues/{Id}/edit"
 @using Microsoft.AspNetCore.Authorization
 @using Web.Auth

--- a/src/Web/Components/Pages/Issues/Index.razor
+++ b/src/Web/Components/Pages/Issues/Index.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Index.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @page "/issues"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Web/Components/Shared/CategoryBadge.razor
+++ b/src/Web/Components/Shared/CategoryBadge.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     CategoryBadge.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Domain.DTOs
 
 <span class="@GetBadgeClasses()">

--- a/src/Web/Components/Shared/DateRangePicker.razor
+++ b/src/Web/Components/Shared/DateRangePicker.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     DateRangePicker.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
 	<div class="flex flex-wrap gap-2">
 		<button @onclick="() => SelectPreset(7)"

--- a/src/Web/Components/Shared/DeleteConfirmationModal.razor
+++ b/src/Web/Components/Shared/DeleteConfirmationModal.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     DeleteConfirmationModal.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @if (IsVisible)
 {
 	<div class="fixed inset-0 z-50 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">

--- a/src/Web/Components/Shared/FileUpload.razor
+++ b/src/Web/Components/Shared/FileUpload.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     FileUpload.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Microsoft.AspNetCore.Components.Forms
 @using Domain.Models
 

--- a/src/Web/Components/Shared/FilterPanel.razor
+++ b/src/Web/Components/Shared/FilterPanel.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     FilterPanel.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Domain.DTOs
 
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow">

--- a/src/Web/Components/Shared/Pagination.razor
+++ b/src/Web/Components/Shared/Pagination.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     Pagination.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @if (TotalPages > 1)
 {
 	<nav class="flex items-center justify-between border-t border-gray-200 dark:border-gray-700 px-4 sm:px-0 mt-6 pt-4">

--- a/src/Web/Components/Shared/SearchInput.razor
+++ b/src/Web/Components/Shared/SearchInput.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     SearchInput.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @implements IDisposable
 
 <div class="relative">

--- a/src/Web/Components/Shared/StatusBadge.razor
+++ b/src/Web/Components/Shared/StatusBadge.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     StatusBadge.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 @using Domain.DTOs
 
 <span class="@GetBadgeClasses()">

--- a/src/Web/Components/Shared/SummaryCard.razor
+++ b/src/Web/Components/Shared/SummaryCard.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     SummaryCard.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web
-// ======================================================= *@
-
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 border border-gray-200 dark:border-gray-700">
 	<div class="flex items-center justify-between">
 		<div class="flex-1">

--- a/tests/Web.Tests.Bunit/_Imports.razor
+++ b/tests/Web.Tests.Bunit/_Imports.razor
@@ -1,12 +1,3 @@
-@* =======================================================
-// Copyright (c) 2025. All rights reserved.
-// File Name :     _Imports.razor
-// Company :       mpaulosky
-// Author :        Matthew Paulosky
-// Solution Name : IssueTrackerApp
-// Project Name :  Web.Tests.Bunit
-// ======================================================= *@
-
 @using Bunit
 
 @using Microsoft.AspNetCore.Components


### PR DESCRIPTION
## Summary
Removes 8-line copyright header blocks from all 30 \.razor\ files and updates \.editorconfig\ to prevent future headers on Razor files.

## Changes
- **30 .razor files**: Removed copyright headers (8-line blocks wrapped in \@* ... *@\)
- **.editorconfig**: Added \ile_header_template = unset\ for \[*.razor]\ section with comment explaining policy

## Files Cleaned
| Category | Count | Files |
|----------|-------|-------|
| Issues Components | 8 | AttachmentCard, AttachmentList, BulkActionToolbar, etc. |
| Shared Components | 9 | CategoryBadge, DateRangePicker, DeleteConfirmationModal, etc. |
| Pages | 9 | Dashboard, Admin/*, Issues/* |
| Charts | 3 | BarChart, LineChart, PieChart |
| Tests | 1 | _Imports.razor |

## Policy
**Copyright headers are required only on \*.cs\ files**, not on \.razor\ files.

## Testing
No functional changes - cosmetic cleanup only.