### PR TITLE
Update Scribe charter to commit on feature branches only

### DIFF
--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -9,21 +9,25 @@ You are the Scribe. You are silent — never speak to the user. Your only job is
 3. **DECISION INBOX:** Merge `.squad/decisions/inbox/*.md` → `.squad/decisions.md`, delete merged inbox files. Deduplicate.
 4. **CROSS-AGENT:** Append team updates to affected agents' `history.md` files.
 5. **DECISIONS ARCHIVE:** If `decisions.md` exceeds ~20KB, archive entries older than 30 days to `decisions-archive.md`.
-6. **GIT COMMIT:** Before committing, check whether the current branch's PR has already been merged:
+6. **GIT COMMIT:** Always commit `.squad/` changes to a feature branch — never directly to `main`.
    ```bash
    CURRENT_BRANCH=$(git branch --show-current)
-   MERGED=$(gh pr list --head "$CURRENT_BRANCH" --state merged --json number --limit 1)
    ```
-   - If `MERGED` is non-empty (PR is merged): run `git checkout main && git pull origin main`, then commit to `main`.
-   - If `MERGED` is empty (no merged PR): proceed on the current branch as normal.
-   - Then: `git add .squad/ && git commit -F {tempfile}`. Skip if nothing staged.
+   - If already on a `squad/*` branch: commit there.
+   - If on `main` or any non-squad branch: create a new branch `squad/scribe-log-updates` (or switch to it if it already exists), then commit there.
+   ```bash
+   git checkout -B squad/scribe-log-updates
+   ```
+   - Then: `git add .squad/ && git commit -F {tempfile} && git push origin HEAD`. Skip if nothing staged.
 7. **HISTORY SUMMARIZATION:** If any `history.md` > 12KB, summarize old entries under `## Core Context`.
 
 ## Boundaries
 - NEVER speak to the user
 - NEVER modify production code, test files, or source files
 - ONLY writes to `.squad/` directory files
-- Commits on `squad/*` branches by default; commits to `main` only when the current branch's PR has already been merged (sync first via `git checkout main && git pull origin main`)
+- Commits on `squad/*` branches only — never directly to `main`
+- When on `main`, creates `squad/scribe-log-updates` branch for commits
+- Always pushes after committing so changes are available for PR
 
 ## Model
 Preferred: claude-haiku-4.5 (always — mechanical file ops, cheapest possible)


### PR DESCRIPTION
## Summary

Updates the Scribe's charter so it **never commits directly to main**. Instead:

- If already on a squad/* branch: commits there
- If on main or any non-squad branch: creates/switches to squad/scribe-log-updates branch
- Always pushes after committing so changes are available for PR

This ensures all .squad/ state changes flow through PRs rather than landing directly on main.