### PR TITLE
feat: Consolidate header navigation into NavMenuComponent

### DIFF
--- a/src/Web/Components/Layout/MainLayout.razor
+++ b/src/Web/Components/Layout/MainLayout.razor
@@ -2,63 +2,7 @@
 
 <ThemeProvider>
 	<div class="min-h-screen flex flex-col bg-primary-950 dark:bg-primary-50 transition-colors duration-200">
-		<header class="bg-primary-900 dark:bg-primary-100 shadow-sm border-b border-primary-800 dark:border-primary-200 sticky top-0 z-40 relative">
-			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between">
-				<div class="flex items-center gap-6">
-					<AuthorizeView>
-						<Authorized>
-							<button type="button"
-								@onclick="ToggleMobileMenu"
-								class="md:hidden p-2 rounded-lg text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-primary-500"
-								aria-label="@(_mobileMenuOpen ? "Close menu" : "Open menu")"
-								aria-expanded="@_mobileMenuOpen">
-								@if (_mobileMenuOpen)
-								{
-									<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-									</svg>
-								}
-								else
-								{
-									<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-									</svg>
-								}
-							</button>
-						</Authorized>
-					</AuthorizeView>
-					<a href="/" class="text-xl font-semibold text-white dark:text-gray-900 hover:text-primary-300 dark:hover:text-primary-600 transition-colors whitespace-nowrap">
-						IssueTracker
-					</a>
-					<AuthorizeView>
-						<Authorized>
-							<NavMenuComponent @bind-MobileMenuOpen="_mobileMenuOpen" />
-						</Authorized>
-					</AuthorizeView>
-				</div>
-				<div class="flex items-center gap-2">
-					<button
-						type="button"
-						onclick="(function(){var t=window.themeManager;t.setBrightness(t.getBrightness()==='dark'?'light':'dark');})()"
-						class="p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
-						aria-label="Toggle brightness"
-						title="Toggle light/dark">
-						<svg class="w-5 h-5 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
-						</svg>
-						<svg class="w-5 h-5 block dark:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
-						</svg>
-					</button>
-					<LoginDisplay />
-					<AuthorizeView>
-						<Authorized>
-							<SignalRConnection />
-						</Authorized>
-					</AuthorizeView>
-				</div>
-			</div>
-		</header>
+		<NavMenuComponent />
 		<main class="flex-1 px-4 sm:px-6 lg:px-8 py-6 text-gray-100 dark:text-gray-900">
 			<div class="max-w-7xl mx-auto">
 				@Body
@@ -74,12 +18,3 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
-
-@code {
-	private bool _mobileMenuOpen;
-
-	private void ToggleMobileMenu()
-	{
-		_mobileMenuOpen = !_mobileMenuOpen;
-	}
-}

--- a/src/Web/Components/Layout/NavMenuComponent.razor
+++ b/src/Web/Components/Layout/NavMenuComponent.razor
@@ -1,123 +1,160 @@
 ﻿@using Web.Auth
 @implements IDisposable
 
-@* Desktop navigation — horizontal bar, hidden on mobile *@
-<nav class="hidden md:flex items-center gap-1" aria-label="Main navigation">
-	<AuthorizeView Policy="@AuthorizationPolicies.UserPolicy">
-		<Authorized>
-			<NavLink href="/" Match="NavLinkMatch.All"
-				class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-				ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-				Home
-			</NavLink>
-			<NavLink href="/dashboard" Match="NavLinkMatch.All"
-				class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-				ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-				Dashboard
-			</NavLink>
-			<NavLink href="/issues" Match="NavLinkMatch.Prefix"
-				class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-				ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-				Issues
-			</NavLink>
-			<NavLink href="/issues/create" Match="NavLinkMatch.All"
-				class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-				ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-				Create
-			</NavLink>
-
-			<AuthorizeView Policy="@AuthorizationPolicies.AdminPolicy" Context="adminContext">
+<header class="bg-primary-900 dark:bg-primary-100 shadow-sm border-b border-primary-800 dark:border-primary-200 sticky top-0 z-40 relative">
+	<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between">
+		<div class="flex items-center gap-6">
+			<AuthorizeView>
 				<Authorized>
-					<span class="h-5 w-px bg-gray-300 dark:bg-gray-600 mx-1"></span>
-					<NavLink href="/admin" Match="NavLinkMatch.All"
-						class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-						ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-						Admin
-					</NavLink>
-					<NavLink href="/admin/categories" Match="NavLinkMatch.All"
-						class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-						ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-						Categories
-					</NavLink>
-					<NavLink href="/admin/statuses" Match="NavLinkMatch.All"
-						class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-						ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-						Statuses
-					</NavLink>
-					<NavLink href="/admin/analytics" Match="NavLinkMatch.All"
-						class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-						ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
-						Analytics
-					</NavLink>
+					<button type="button"
+						@onclick="ToggleMobileMenu"
+						class="md:hidden p-2 rounded-lg text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-primary-500"
+						aria-label="@(_mobileMenuOpen ? "Close menu" : "Open menu")"
+						aria-expanded="@_mobileMenuOpen">
+						@if (_mobileMenuOpen)
+						{
+							<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+							</svg>
+						}
+						else
+						{
+							<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+							</svg>
+						}
+					</button>
 				</Authorized>
 			</AuthorizeView>
-		</Authorized>
-	</AuthorizeView>
-</nav>
+			<a href="/" class="text-xl font-semibold text-white dark:text-gray-900 hover:text-primary-300 dark:hover:text-primary-600 transition-colors whitespace-nowrap">
+				IssueTracker
+			</a>
+			@* Desktop navigation — horizontal bar, hidden on mobile *@
+			<nav class="hidden md:flex items-center gap-1" aria-label="Main navigation">
+				<AuthorizeView Policy="@AuthorizationPolicies.UserPolicy">
+					<Authorized>
+						<NavLink href="/" Match="NavLinkMatch.All"
+							class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+							ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+							Home
+						</NavLink>
+						<NavLink href="/dashboard" Match="NavLinkMatch.All"
+							class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+							ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+							Dashboard
+						</NavLink>
+						<NavLink href="/issues" Match="NavLinkMatch.Prefix"
+							class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+							ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+							Issues
+						</NavLink>
+						<NavLink href="/issues/create" Match="NavLinkMatch.All"
+							class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+							ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+							Create
+						</NavLink>
 
-@* Mobile navigation — dropdown panel, hidden on desktop *@
-@if (_mobileMenuOpen)
-{
-	<div class="md:hidden absolute left-0 right-0 top-full bg-primary-900 dark:bg-primary-100 border-t border-primary-800 dark:border-primary-200 shadow-lg z-50">
-		<nav class="flex flex-col px-4 py-3 space-y-1" aria-label="Mobile navigation">
-			<AuthorizeView Policy="@AuthorizationPolicies.UserPolicy">
+						<AuthorizeView Policy="@AuthorizationPolicies.AdminPolicy" Context="adminContext">
+							<Authorized>
+								<span class="h-5 w-px bg-gray-300 dark:bg-gray-600 mx-1"></span>
+								<NavLink href="/admin" Match="NavLinkMatch.All"
+									class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+									ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+									Admin
+								</NavLink>
+								<NavLink href="/admin/categories" Match="NavLinkMatch.All"
+									class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+									ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+									Categories
+								</NavLink>
+								<NavLink href="/admin/statuses" Match="NavLinkMatch.All"
+									class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+									ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+									Statuses
+								</NavLink>
+								<NavLink href="/admin/analytics" Match="NavLinkMatch.All"
+									class="px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+									ActiveClass="bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+									Analytics
+								</NavLink>
+							</Authorized>
+						</AuthorizeView>
+					</Authorized>
+				</AuthorizeView>
+			</nav>
+		</div>
+		<div class="flex items-center gap-2">
+			<ThemeToggle />
+			<LoginDisplay />
+			<AuthorizeView>
 				<Authorized>
-					<NavLink href="/" Match="NavLinkMatch.All"
-						class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-						ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-						Home
-					</NavLink>
-					<NavLink href="/dashboard" Match="NavLinkMatch.All"
-						class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-						ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-						Dashboard
-					</NavLink>
-					<NavLink href="/issues" Match="NavLinkMatch.Prefix"
-						class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-						ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-						Issues
-					</NavLink>
-					<NavLink href="/issues/create" Match="NavLinkMatch.All"
-						class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-						ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-						Create
-					</NavLink>
-
-					<AuthorizeView Policy="@AuthorizationPolicies.AdminPolicy" Context="adminMobileContext">
-						<Authorized>
-							<hr class="border-primary-700 dark:border-primary-300 my-1" />
-							<NavLink href="/admin" Match="NavLinkMatch.All"
-								class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-								ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-								Admin
-							</NavLink>
-							<NavLink href="/admin/categories" Match="NavLinkMatch.All"
-								class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-								ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-								Categories
-							</NavLink>
-							<NavLink href="/admin/statuses" Match="NavLinkMatch.All"
-								class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-								ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-								Statuses
-							</NavLink>
-							<NavLink href="/admin/analytics" Match="NavLinkMatch.All"
-								class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
-								ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
-								Analytics
-							</NavLink>
-						</Authorized>
-					</AuthorizeView>
+					<SignalRConnection />
 				</Authorized>
 			</AuthorizeView>
-		</nav>
+		</div>
 	</div>
-}
+
+	@* Mobile navigation — dropdown panel, hidden on desktop *@
+	@if (_mobileMenuOpen)
+	{
+		<div class="md:hidden absolute left-0 right-0 top-full bg-primary-900 dark:bg-primary-100 border-t border-primary-800 dark:border-primary-200 shadow-lg z-50">
+			<nav class="flex flex-col px-4 py-3 space-y-1" aria-label="Mobile navigation">
+				<AuthorizeView Policy="@AuthorizationPolicies.UserPolicy">
+					<Authorized>
+						<NavLink href="/" Match="NavLinkMatch.All"
+							class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+							ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+							Home
+						</NavLink>
+						<NavLink href="/dashboard" Match="NavLinkMatch.All"
+							class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+							ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+							Dashboard
+						</NavLink>
+						<NavLink href="/issues" Match="NavLinkMatch.Prefix"
+							class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+							ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+							Issues
+						</NavLink>
+						<NavLink href="/issues/create" Match="NavLinkMatch.All"
+							class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+							ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+							Create
+						</NavLink>
+
+						<AuthorizeView Policy="@AuthorizationPolicies.AdminPolicy" Context="adminMobileContext">
+							<Authorized>
+								<hr class="border-primary-700 dark:border-primary-300 my-1" />
+								<NavLink href="/admin" Match="NavLinkMatch.All"
+									class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+									ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+									Admin
+								</NavLink>
+								<NavLink href="/admin/categories" Match="NavLinkMatch.All"
+									class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+									ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+									Categories
+								</NavLink>
+								<NavLink href="/admin/statuses" Match="NavLinkMatch.All"
+									class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+									ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+									Statuses
+								</NavLink>
+								<NavLink href="/admin/analytics" Match="NavLinkMatch.All"
+									class="block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 text-gray-300 dark:text-gray-600 hover:bg-primary-800 dark:hover:bg-gray-200 hover:text-white dark:hover:text-gray-900"
+									ActiveClass="bg-primary-800 dark:bg-primary-200 text-white dark:text-gray-900">
+									Analytics
+								</NavLink>
+							</Authorized>
+						</AuthorizeView>
+					</Authorized>
+				</AuthorizeView>
+			</nav>
+		</div>
+	}
+</header>
 
 @code {
-	[Parameter] public bool MobileMenuOpen { get => _mobileMenuOpen; set => _mobileMenuOpen = value; }
-	[Parameter] public EventCallback<bool> MobileMenuOpenChanged { get; set; }
-
 	private bool _mobileMenuOpen;
 
 	[Inject] private NavigationManager Navigation { get; set; } = default!;
@@ -127,12 +164,16 @@
 		Navigation.LocationChanged += OnLocationChanged;
 	}
 
+	private void ToggleMobileMenu()
+	{
+		_mobileMenuOpen = !_mobileMenuOpen;
+	}
+
 	private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
 	{
 		if (_mobileMenuOpen)
 		{
 			_mobileMenuOpen = false;
-			MobileMenuOpenChanged.InvokeAsync(false);
 			StateHasChanged();
 		}
 	}

--- a/src/Web/Styles/input.css
+++ b/src/Web/Styles/input.css
@@ -188,11 +188,11 @@
 
 	/* Cards */
 	.card {
-		@apply bg-white dark:bg-gray-800 rounded-lg shadow;
+		@apply bg-primary-400 dark:bg-primary-900 rounded-lg shadow;
 	}
 
 	.card-bordered {
-		@apply bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-200 dark:border-gray-700;
+		@apply bg-primary-400 dark:bg-primary-900 rounded-lg shadow-md border border-primary-300 dark:border-primary-800;
 	}
 
 	.card-section {
@@ -200,7 +200,7 @@
 	}
 
 	.card-footer {
-		@apply bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6;
+		@apply bg-primary-300 dark:bg-primary-950 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6;
 	}
 
 	/* Forms */


### PR DESCRIPTION
## Summary
Closes #69. Partially addresses #66.

## Changes

### `NavMenuComponent.razor` — now owns the full header
- Added `<header>` wrapper (sticky, z-indexed, with existing CSS)
- Moved logo link (`IssueTracker`) from `MainLayout`
- Moved mobile hamburger button from `MainLayout`; component now owns `_mobileMenuOpen` state internally
- Removed `MobileMenuOpen` / `MobileMenuOpenChanged` parameters (no longer needed)
- Replaced inline `window.themeManager` brightness button with `<ThemeToggle />`
- Added `<LoginDisplay />` and `<AuthorizeView><SignalRConnection /></AuthorizeView>`

### `MainLayout.razor` — thin layout shell
- Removed entire `<header>` block and `@code` section
- Now just: `<NavMenuComponent />` + `<main>` + `<FooterComponent />`

### `input.css` — card theme fix (issue #70)
- `.card`, `.card-bordered`, `.card-footer` now use `primary-*` colors instead of hardcoded `gray-*`/`white`

## Test Results
✅ All 622 bUnit tests pass with no regressions