### PR TITLE
feat(web): add /Account/AccessDenied Blazor page

### DIFF
--- a/src/Web/Components/Pages/Account/AccessDenied.razor
+++ b/src/Web/Components/Pages/Account/AccessDenied.razor
@@ -1,0 +1,27 @@
+@*
+ * Copyright (c) 2025 Matthew Paulosky. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *@
+
+@page "/Account/AccessDenied"
+@layout MainLayout
+
+<PageTitle>Access Denied - IssueTracker</PageTitle>
+
+<div class="flex items-center justify-center min-h-[60vh]">
+	<div class="max-w-lg mx-auto text-center card-bordered shadow-xl p-12">
+		<div class="text-6xl mb-6">🚫</div>
+		<h1 class="text-4xl font-bold text-neutral-900 dark:text-white mb-4">
+			Access Denied
+		</h1>
+		<p class="text-lg text-neutral-600 dark:text-neutral-300 mb-3">
+			You don't have permission to view that page.
+		</p>
+		<p class="text-sm text-neutral-500 dark:text-neutral-400 mb-8">
+			This area is restricted to administrators. If you believe this is a mistake, please contact your system administrator.
+		</p>
+		<a href="/" class="btn-primary inline-block px-8 py-3 rounded-lg transition-colors shadow-md">
+			Return to Home
+		</a>
+	</div>
+</div>


### PR DESCRIPTION
Closes #77

Working as Legolas (Frontend Developer)

### Problem
When a non-admin user is denied access, they are redirected to `/Account/AccessDenied`. Without a Blazor component at this route, they hit a NotFound page instead of a helpful message.

### Solution
Added `src/Web/Components/Pages/Account/AccessDenied.razor` with a friendly Access Denied message and a link back to the home page.