### PR TITLE
fix(tests): DisableDashboard consistency, stronger assertions, descriptive timeout

### DIFF
--- a/tests/AppHost.Tests/BasePlaywrightTests.cs
+++ b/tests/AppHost.Tests/BasePlaywrightTests.cs
@@ -135,23 +135,30 @@ public abstract class BasePlaywrightTests : IAsyncDisposable
 
 		using var cts = new CancellationTokenSource(timeout);
 
-		while (!cts.Token.IsCancellationRequested)
+		try
 		{
-			try
+			while (!cts.Token.IsCancellationRequested)
 			{
-				var response = await client.GetAsync("/health", cts.Token);
-				if (response.IsSuccessStatusCode)
-					return;
-			}
-			catch (Exception) when (!cts.Token.IsCancellationRequested)
-			{
-				// Connection refused / SSL error during startup — keep polling
-			}
+				try
+				{
+					var response = await client.GetAsync("/health", cts.Token);
+					if (response.IsSuccessStatusCode)
+						return;
+				}
+				catch (Exception) when (!cts.Token.IsCancellationRequested)
+				{
+					// Connection refused / SSL error during startup — keep polling
+				}
 
-			await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
+				await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
+			}
+		}
+		catch (OperationCanceledException)
+		{
+			// timeout fired — fall through to TimeoutException below
 		}
 
-		throw new TimeoutException($"Web resource at {endpoint} did not become healthy within {timeout}.");
+		throw new TimeoutException($"Web app at {endpoint} was not ready after {timeout.TotalSeconds}s");
 	}
 
 	public async ValueTask DisposeAsync()

--- a/tests/AppHost.Tests/EnvVarTests.cs
+++ b/tests/AppHost.Tests/EnvVarTests.cs
@@ -22,7 +22,12 @@ public class EnvVarTests
 	{
 		// Arrange
 		var appHost = await DistributedApplicationTestingBuilder
-			.CreateAsync<Projects.AppHost>();
+			.CreateAsync<Projects.AppHost>(
+				args: [],
+				configureBuilder: static (options, _) =>
+				{
+					options.DisableDashboard = true;
+				});
 
 		var webResource = (IResourceWithEnvironment)appHost.Resources
 			.Single(static r => r.Name == "web");
@@ -42,7 +47,12 @@ public class EnvVarTests
 	{
 		// Arrange
 		var appHost = await DistributedApplicationTestingBuilder
-			.CreateAsync<Projects.AppHost>();
+			.CreateAsync<Projects.AppHost>(
+				args: [],
+				configureBuilder: static (options, _) =>
+				{
+					options.DisableDashboard = true;
+				});
 
 		var webResource = (IResourceWithEnvironment)appHost.Resources
 			.Single(static r => r.Name == "web");

--- a/tests/AppHost.Tests/Tests/Admin/AdminPageTests.cs
+++ b/tests/AppHost.Tests/Tests/Admin/AdminPageTests.cs
@@ -51,7 +51,7 @@ public class AdminPageTests : BasePlaywrightTests
 			var heading = page.Locator("h1");
 			await heading.WaitForAsync();
 			var text = await heading.InnerTextAsync();
-			text.Should().NotBeNullOrWhiteSpace();
+			text.Should().Be("Admin Dashboard");
 		});
 	}
 


### PR DESCRIPTION
Closes #78
Closes #79
Closes #80

Working as Pippin (E2E & Aspire Tester)

### Changes
- **#79** `EnvVarTests.cs`: Added `DisableDashboard = true` to the `DistributedApplicationTestingBuilder` for consistency with all other test builders
- **#80** `AdminPageTests.cs`: Replaced `NotBeNullOrWhiteSpace` with specific heading text assertion
- **#78** `BasePlaywrightTests.cs`: `WaitForWebReadyAsync` now throws `TimeoutException` with descriptive message instead of letting `OperationCanceledException` propagate