### PR TITLE
docs: add Latest Release badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A modern issue tracking application built with .NET Aspire, Blazor, and MongoDB.
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![xUnit Tests](https://img.shields.io/badge/Tests-xUnit-blueviolet?logo=github)](https://github.com/mpaulosky/IssueTrackerApp/actions/workflows/squad-ci.yml)
+[![Latest Release](https://img.shields.io/github/v/release/mpaulosky/IssueTrackerApp?logo=github&color=blue&label=Release)](https://github.com/mpaulosky/IssueTrackerApp/releases/latest)
 
 [![CI/CD](https://github.com/mpaulosky/IssueTrackerApp/actions/workflows/squad-ci.yml/badge.svg)](https://github.com/mpaulosky/IssueTrackerApp/actions/workflows/squad-ci.yml)
 [![Test Suite](https://github.com/mpaulosky/IssueTrackerApp/actions/workflows/squad-test.yml/badge.svg)](https://github.com/mpaulosky/IssueTrackerApp/actions/workflows/squad-test.yml)


### PR DESCRIPTION
## Summary

Adds a shields.io **Latest Release** badge to the first badge row in `README.md`.

```markdown
[![Latest Release](https://img.shields.io/github/v/release/mpaulosky/IssueTrackerApp?logo=github&color=blue&label=Release)](https://github.com/mpaulosky/IssueTrackerApp/releases/latest)
```

The badge auto-updates via the shields.io GitHub API whenever a new GitHub Release is published — no workflow changes needed.

## Before / After

**Before:** .NET 10 · MIT License · xUnit Tests  
**After:** .NET 10 · MIT License · xUnit Tests · **Release v0.1.0** (auto-updated on each release)

## Notes
- `docs/README.md` will be auto-synced by the existing `sync-readme.yml` workflow after this PR merges to `main`
- Badge will show `v0.2.0` automatically once the milestone release workflow cuts the next tag