### PR TITLE
test: unit tests for UserManagementService and Admin MediatR handlers (#141)

### DIFF
--- a/tests/Domain.Tests/Features/Admin/AssignRoleCommandHandlerTests.cs
+++ b/tests/Domain.Tests/Features/Admin/AssignRoleCommandHandlerTests.cs
@@ -1,0 +1,180 @@
+// =======================================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     AssignRoleCommandHandlerTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain.Tests
+// =======================================================
+
+using Domain.Features.Admin.Abstractions;
+using Domain.Features.Admin.Models;
+using Domain.Features.Admin.Users.Commands;
+
+namespace Domain.Tests.Features.Admin;
+
+/// <summary>
+///   Unit tests for <see cref="AssignRoleCommandHandler" />.
+/// </summary>
+public sealed class AssignRoleCommandHandlerTests
+{
+	private readonly IUserManagementService _userManagementService;
+	private readonly IAuditLogRepository _auditLogRepository;
+	private readonly IMediator _mediator;
+	private readonly ILogger<AssignRoleCommandHandler> _logger;
+	private readonly AssignRoleCommandHandler _sut;
+
+	public AssignRoleCommandHandlerTests()
+	{
+		_userManagementService = Substitute.For<IUserManagementService>();
+		_auditLogRepository = Substitute.For<IAuditLogRepository>();
+		_mediator = Substitute.For<IMediator>();
+		_logger = Substitute.For<ILogger<AssignRoleCommandHandler>>();
+		_sut = new AssignRoleCommandHandler(
+			_userManagementService,
+			_auditLogRepository,
+			_mediator,
+			_logger);
+	}
+
+	[Fact]
+	public async Task Handle_SuccessPath_ReturnsTrueResult()
+	{
+		// Arrange
+		var command = new AssignRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.AssignRolesAsync("user|1", Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(true));
+
+		// Act
+		var result = await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Handle_SuccessPath_PersistsAuditEntryWithCorrectData()
+	{
+		// Arrange
+		var command = new AssignRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.AssignRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(true));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _auditLogRepository.Received(1).AddAsync(
+			Arg.Is<RoleChangeAuditEntry>(e =>
+				e.AdminUserId == "admin|1" &&
+				e.AdminUserName == "Admin User" &&
+				e.TargetUserId == "user|1" &&
+				e.RoleName == "Admin" &&
+				e.Action == "assigned"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_SuccessPath_PublishesRoleAssignedEvent()
+	{
+		// Arrange
+		var command = new AssignRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.AssignRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(true));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _mediator.Received(1).Publish(
+			Arg.Is<RoleAssignedEvent>(e =>
+				e.AdminUserId == "admin|1" &&
+				e.TargetUserId == "user|1" &&
+				e.RoleName == "Admin"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_Auth0ApiError_PropagatesExternalServiceErrorCode()
+	{
+		// Arrange
+		var command = new AssignRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.AssignRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Auth0 Management API returned 503", ResultErrorCode.ExternalService));
+
+		// Act
+		var result = await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.ExternalService);
+	}
+
+	[Fact]
+	public async Task Handle_ServiceFailure_DoesNotPersistAuditEntry()
+	{
+		// Arrange
+		var command = new AssignRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.AssignRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Auth0 API error", ResultErrorCode.ExternalService));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _auditLogRepository.DidNotReceive()
+			.AddAsync(Arg.Any<RoleChangeAuditEntry>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_ServiceFailure_DoesNotPublishRoleAssignedEvent()
+	{
+		// Arrange
+		var command = new AssignRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.AssignRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Auth0 API error", ResultErrorCode.ExternalService));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _mediator.DidNotReceive()
+			.Publish(Arg.Any<RoleAssignedEvent>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_ValidationFailure_PropagatesValidationErrorCode()
+	{
+		// Arrange - unknown role name causes validation error from service
+		var command = new AssignRoleCommand("admin|1", "Admin User", "user|1", "NonExistentRole");
+
+		_userManagementService
+			.AssignRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Unknown role(s): NonExistentRole", ResultErrorCode.Validation));
+
+		// Act
+		var result = await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+	}
+
+	// TODO: The handler does not currently enforce caller authorization (AdminUserId validity).
+	// Authorization is handled by ASP.NET Core policy at the endpoint layer (RequireAuthorization("AdminPolicy")).
+	// If a dedicated Unauthorized check is needed inside the handler, add it and test here.
+	// Expected: Result.Fail<bool>("...", ResultErrorCode.Unauthorized) if that code is added to the enum.
+}

--- a/tests/Domain.Tests/Features/Admin/ListUsersQueryHandlerTests.cs
+++ b/tests/Domain.Tests/Features/Admin/ListUsersQueryHandlerTests.cs
@@ -1,0 +1,183 @@
+// =======================================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     ListUsersQueryHandlerTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain.Tests
+// =======================================================
+
+using Domain.Features.Admin.Abstractions;
+using Domain.Features.Admin.Models;
+using Domain.Features.Admin.Users.Queries;
+
+namespace Domain.Tests.Features.Admin;
+
+/// <summary>
+///   Unit tests for <see cref="ListUsersQueryHandler" />.
+/// </summary>
+public sealed class ListUsersQueryHandlerTests
+{
+	private readonly IUserManagementService _userManagementService;
+	private readonly ILogger<ListUsersQueryHandler> _logger;
+	private readonly ListUsersQueryHandler _sut;
+
+	public ListUsersQueryHandlerTests()
+	{
+		_userManagementService = Substitute.For<IUserManagementService>();
+		_logger = Substitute.For<ILogger<ListUsersQueryHandler>>();
+		_sut = new ListUsersQueryHandler(_userManagementService, _logger);
+	}
+
+	[Fact]
+	public async Task Handle_WithUsers_ReturnsSuccessWithUserList()
+	{
+		// Arrange
+		var users = new List<AdminUserSummary>
+		{
+			new() { UserId = "auth0|1", Email = "alice@example.com", Name = "Alice Smith" },
+			new() { UserId = "auth0|2", Email = "bob@example.com", Name = "Bob Jones" }
+		};
+		var query = new ListUsersQuery(1, 10, null);
+
+		_userManagementService
+			.ListUsersAsync(1, 10, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IReadOnlyList<AdminUserSummary>>(users));
+
+		// Act
+		var result = await _sut.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().HaveCount(2);
+		result.Value![0].Email.Should().Be("alice@example.com");
+	}
+
+	[Fact]
+	public async Task Handle_EmptyUserList_ReturnsSuccessWithEmptyList()
+	{
+		// Arrange
+		var query = new ListUsersQuery(1, 10, null);
+
+		_userManagementService
+			.ListUsersAsync(1, 10, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IReadOnlyList<AdminUserSummary>>(new List<AdminUserSummary>()));
+
+		// Act
+		var result = await _sut.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Handle_PaginationParams_ForwardedToService()
+	{
+		// Arrange
+		var query = new ListUsersQuery(3, 25, null);
+
+		_userManagementService
+			.ListUsersAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IReadOnlyList<AdminUserSummary>>(new List<AdminUserSummary>()));
+
+		// Act
+		await _sut.Handle(query, CancellationToken.None);
+
+		// Assert
+		await _userManagementService.Received(1)
+			.ListUsersAsync(3, 25, Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_WithSearchTerm_FiltersMatchingUsersOnly()
+	{
+		// Arrange
+		var users = new List<AdminUserSummary>
+		{
+			new() { UserId = "auth0|1", Email = "alice@example.com", Name = "Alice Smith" },
+			new() { UserId = "auth0|2", Email = "bob@example.com", Name = "Bob Jones" }
+		};
+		var query = new ListUsersQuery(1, 10, "alice");
+
+		_userManagementService
+			.ListUsersAsync(1, 10, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IReadOnlyList<AdminUserSummary>>(users));
+
+		// Act
+		var result = await _sut.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().HaveCount(1);
+		result.Value![0].Name.Should().Be("Alice Smith");
+	}
+
+	[Fact]
+	public async Task Handle_SearchTermMatchesEmail_ReturnsMatchingUser()
+	{
+		// Arrange
+		var users = new List<AdminUserSummary>
+		{
+			new() { UserId = "auth0|1", Email = "alice@example.com", Name = "Alice Smith" },
+			new() { UserId = "auth0|2", Email = "bob@example.com", Name = "Bob Jones" }
+		};
+		var query = new ListUsersQuery(1, 10, "bob@example.com");
+
+		_userManagementService
+			.ListUsersAsync(1, 10, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IReadOnlyList<AdminUserSummary>>(users));
+
+		// Act
+		var result = await _sut.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().HaveCount(1);
+		result.Value![0].UserId.Should().Be("auth0|2");
+	}
+
+	[Fact]
+	public async Task Handle_NullSearchTerm_ReturnsAllUsers()
+	{
+		// Arrange
+		var users = new List<AdminUserSummary>
+		{
+			new() { UserId = "auth0|1", Email = "alice@example.com", Name = "Alice" },
+			new() { UserId = "auth0|2", Email = "bob@example.com", Name = "Bob" }
+		};
+		var query = new ListUsersQuery(1, 10, null);
+
+		_userManagementService
+			.ListUsersAsync(1, 10, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IReadOnlyList<AdminUserSummary>>(users));
+
+		// Act
+		var result = await _sut.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task Handle_ServiceReturnsFailure_PropagatesErrorAndCode()
+	{
+		// Arrange
+		var query = new ListUsersQuery(1, 10, null);
+
+		_userManagementService
+			.ListUsersAsync(1, 10, Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<IReadOnlyList<AdminUserSummary>>(
+				"Auth0 connection failed",
+				ResultErrorCode.ExternalService));
+
+		// Act
+		var result = await _sut.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.ExternalService);
+		result.Error.Should().Be("Auth0 connection failed");
+	}
+}

--- a/tests/Domain.Tests/Features/Admin/RemoveRoleCommandHandlerTests.cs
+++ b/tests/Domain.Tests/Features/Admin/RemoveRoleCommandHandlerTests.cs
@@ -1,0 +1,179 @@
+// =======================================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     RemoveRoleCommandHandlerTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain.Tests
+// =======================================================
+
+using Domain.Features.Admin.Abstractions;
+using Domain.Features.Admin.Models;
+using Domain.Features.Admin.Users.Commands;
+
+namespace Domain.Tests.Features.Admin;
+
+/// <summary>
+///   Unit tests for <see cref="RemoveRoleCommandHandler" />.
+/// </summary>
+public sealed class RemoveRoleCommandHandlerTests
+{
+	private readonly IUserManagementService _userManagementService;
+	private readonly IAuditLogRepository _auditLogRepository;
+	private readonly IMediator _mediator;
+	private readonly ILogger<RemoveRoleCommandHandler> _logger;
+	private readonly RemoveRoleCommandHandler _sut;
+
+	public RemoveRoleCommandHandlerTests()
+	{
+		_userManagementService = Substitute.For<IUserManagementService>();
+		_auditLogRepository = Substitute.For<IAuditLogRepository>();
+		_mediator = Substitute.For<IMediator>();
+		_logger = Substitute.For<ILogger<RemoveRoleCommandHandler>>();
+		_sut = new RemoveRoleCommandHandler(
+			_userManagementService,
+			_auditLogRepository,
+			_mediator,
+			_logger);
+	}
+
+	[Fact]
+	public async Task Handle_SuccessPath_ReturnsTrueResult()
+	{
+		// Arrange
+		var command = new RemoveRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.RemoveRolesAsync("user|1", Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(true));
+
+		// Act
+		var result = await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Handle_SuccessPath_PersistsAuditEntryWithRemovedAction()
+	{
+		// Arrange
+		var command = new RemoveRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.RemoveRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(true));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _auditLogRepository.Received(1).AddAsync(
+			Arg.Is<RoleChangeAuditEntry>(e =>
+				e.AdminUserId == "admin|1" &&
+				e.AdminUserName == "Admin User" &&
+				e.TargetUserId == "user|1" &&
+				e.RoleName == "Admin" &&
+				e.Action == "removed"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_SuccessPath_PublishesRoleRemovedEvent()
+	{
+		// Arrange
+		var command = new RemoveRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.RemoveRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(true));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _mediator.Received(1).Publish(
+			Arg.Is<RoleRemovedEvent>(e =>
+				e.AdminUserId == "admin|1" &&
+				e.TargetUserId == "user|1" &&
+				e.RoleName == "Admin"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_UserNotFound_PropagatesExternalServiceError()
+	{
+		// Arrange - Auth0 returns 404 for unknown user; service maps this to ExternalService
+		var command = new RemoveRoleCommand("admin|1", "Admin User", "unknown-user", "Admin");
+
+		_userManagementService
+			.RemoveRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Failed to remove roles: Not Found", ResultErrorCode.ExternalService));
+
+		// Act
+		var result = await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.ExternalService);
+	}
+
+	[Fact]
+	public async Task Handle_Auth0ApiError_PropagatesExternalServiceErrorCode()
+	{
+		// Arrange
+		var command = new RemoveRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.RemoveRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Auth0 service unavailable", ResultErrorCode.ExternalService));
+
+		// Act
+		var result = await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.ExternalService);
+	}
+
+	[Fact]
+	public async Task Handle_ServiceFailure_DoesNotPersistAuditEntry()
+	{
+		// Arrange
+		var command = new RemoveRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.RemoveRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Auth0 API error", ResultErrorCode.ExternalService));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _auditLogRepository.DidNotReceive()
+			.AddAsync(Arg.Any<RoleChangeAuditEntry>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_ServiceFailure_DoesNotPublishRoleRemovedEvent()
+	{
+		// Arrange
+		var command = new RemoveRoleCommand("admin|1", "Admin User", "user|1", "Admin");
+
+		_userManagementService
+			.RemoveRolesAsync(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<bool>("Auth0 API error", ResultErrorCode.ExternalService));
+
+		// Act
+		await _sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		await _mediator.DidNotReceive()
+			.Publish(Arg.Any<RoleRemovedEvent>(), Arg.Any<CancellationToken>());
+	}
+
+	// TODO: The handler does not currently enforce caller authorization (AdminUserId validity).
+	// Authorization is handled by ASP.NET Core policy at the endpoint layer (RequireAuthorization("AdminPolicy")).
+	// If a dedicated Unauthorized check is needed inside the handler, add it and test here.
+}

--- a/tests/Web.Tests/Services/UserManagementServiceTests.cs
+++ b/tests/Web.Tests/Services/UserManagementServiceTests.cs
@@ -1,0 +1,279 @@
+// =======================================================
+// Copyright (c) 2026. All rights reserved.
+// File Name :     UserManagementServiceTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Web.Tests
+// =======================================================
+
+using System.Text;
+using System.Text.Json;
+
+using Domain.Abstractions;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+using Web.Features.Admin.Users;
+
+namespace Web.Tests.Services;
+
+/// <summary>
+///   Unit tests for <see cref="UserManagementService" />.
+/// </summary>
+/// <remarks>
+///   <para>
+///     <b>Test coverage note:</b> <see cref="UserManagementService" /> directly instantiates
+///     <see cref="Auth0.ManagementApi.ManagementApiClient" /> with a hardcoded connection, making it
+///     impossible to intercept Management API HTTP calls in pure unit tests. As a result:
+///     <list type="bullet">
+///       <item>Input-validation paths (empty userId, empty roles) are fully covered here.</item>
+///       <item>M2M token-caching behaviour is covered via <see cref="IHttpClientFactory" /> call-count assertions.</item>
+///       <item>
+///         Success paths that require a real Management API response (ListUsersAsync success,
+///         AssignRolesAsync success) require integration tests or a refactor to inject an
+///         <c>IManagementApiClientFactory</c> / <c>HttpClientManagementConnection</c>. See TODO comments.
+///       </item>
+///     </list>
+///   </para>
+/// </remarks>
+public sealed class UserManagementServiceTests
+{
+	private static Auth0ManagementOptions DefaultOptions => new()
+	{
+		ClientId = "test-client-id",
+		ClientSecret = "test-client-secret",
+		Domain = "test-tenant.auth0.com",
+		Audience = "https://test-tenant.auth0.com/api/v2/"
+	};
+
+	private static UserManagementService CreateSut(
+		IMemoryCache? cache = null,
+		IHttpClientFactory? httpClientFactory = null,
+		Auth0ManagementOptions? options = null,
+		ILogger<UserManagementService>? logger = null)
+	{
+		return new UserManagementService(
+			cache ?? new MemoryCache(new MemoryCacheOptions()),
+			httpClientFactory ?? Substitute.For<IHttpClientFactory>(),
+			Options.Create(options ?? DefaultOptions),
+			logger ?? Substitute.For<ILogger<UserManagementService>>());
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Input validation — AssignRolesAsync
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task AssignRolesAsync_EmptyUserId_ReturnsValidationFailure()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.AssignRolesAsync(string.Empty, ["Admin"], CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		result.Error.Should().Contain("User ID");
+	}
+
+	[Fact]
+	public async Task AssignRolesAsync_WhitespaceUserId_ReturnsValidationFailure()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.AssignRolesAsync("   ", ["Admin"], CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+	}
+
+	[Fact]
+	public async Task AssignRolesAsync_EmptyRolesList_ReturnsImmediateSuccess()
+	{
+		// Arrange — no HttpClientFactory call expected because roles list is empty
+		var httpClientFactory = Substitute.For<IHttpClientFactory>();
+		var sut = CreateSut(httpClientFactory: httpClientFactory);
+
+		// Act
+		var result = await sut.AssignRolesAsync("auth0|user1", [], CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeTrue();
+		httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+	}
+
+	[Fact]
+	public async Task AssignRolesAsync_NullRolesList_ReturnsImmediateSuccess()
+	{
+		// Arrange
+		var httpClientFactory = Substitute.For<IHttpClientFactory>();
+		var sut = CreateSut(httpClientFactory: httpClientFactory);
+
+		// Act
+		var result = await sut.AssignRolesAsync("auth0|user1", null!, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Input validation — RemoveRolesAsync
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task RemoveRolesAsync_EmptyUserId_ReturnsValidationFailure()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.RemoveRolesAsync(string.Empty, ["Admin"], CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		result.Error.Should().Contain("User ID");
+	}
+
+	[Fact]
+	public async Task RemoveRolesAsync_EmptyRolesList_ReturnsImmediateSuccess()
+	{
+		// Arrange — no HttpClientFactory call expected
+		var httpClientFactory = Substitute.For<IHttpClientFactory>();
+		var sut = CreateSut(httpClientFactory: httpClientFactory);
+
+		// Act
+		var result = await sut.RemoveRolesAsync("auth0|user1", [], CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().BeTrue();
+		httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Input validation — GetUserByIdAsync
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task GetUserByIdAsync_EmptyUserId_ReturnsValidationFailure()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.GetUserByIdAsync(string.Empty, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// M2M Token caching
+	// ──────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task ListUsersAsync_TokenFetchedOnFirstCall_CachedTokenUsedOnSecondCall()
+	{
+		// Arrange — use a fake HTTP handler that intercepts the token-endpoint call.
+		// ManagementApiClient creates its own HttpClient and will fail to connect to the
+		// fake domain (ExternalService), but the IHttpClientFactory call-count tells us
+		// whether the token was re-fetched.
+		var tokenCallCount = 0;
+		var fakeTokenHandler = new FakeHttpMessageHandler(request =>
+		{
+			tokenCallCount++;
+			var json = JsonSerializer.Serialize(new
+			{
+				access_token = "fake-management-token",
+				token_type = "Bearer",
+				expires_in = 86400
+			});
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(json, Encoding.UTF8, "application/json")
+			};
+		});
+
+		var httpClientFactory = Substitute.For<IHttpClientFactory>();
+		httpClientFactory.CreateClient(Arg.Any<string>())
+			.Returns(new HttpClient(fakeTokenHandler));
+
+		var sut = CreateSut(
+			cache: new MemoryCache(new MemoryCacheOptions()),
+			httpClientFactory: httpClientFactory);
+
+		// Act — two consecutive calls; both will fail at Management API level (ExternalService)
+		// but only the first should trigger a token fetch via IHttpClientFactory.
+		var first = await sut.ListUsersAsync(1, 10, CancellationToken.None);
+		var second = await sut.ListUsersAsync(1, 10, CancellationToken.None);
+
+		// Assert — both return ExternalService (can't reach fake domain), but token was
+		// fetched only once.
+		first.Failure.Should().BeTrue();
+		first.ErrorCode.Should().Be(ResultErrorCode.ExternalService);
+
+		second.Failure.Should().BeTrue();
+		second.ErrorCode.Should().Be(ResultErrorCode.ExternalService);
+
+		// IHttpClientFactory.CreateClient() must have been invoked exactly once across both calls.
+		httpClientFactory.Received(1).CreateClient(Arg.Any<string>());
+	}
+
+	[Fact]
+	public async Task ListUsersAsync_TokenAlreadyInCache_DoesNotCallHttpClientFactory()
+	{
+		// Arrange — pre-populate the cache with a valid token so no HTTP call is needed.
+		var cache = new MemoryCache(new MemoryCacheOptions());
+		cache.Set("Auth0Management:Token", "pre-cached-token", TimeSpan.FromHours(1));
+
+		var httpClientFactory = Substitute.For<IHttpClientFactory>();
+
+		var sut = CreateSut(cache: cache, httpClientFactory: httpClientFactory);
+
+		// Act
+		await sut.ListUsersAsync(1, 10, CancellationToken.None);
+
+		// Assert — factory must NOT be called because token came from cache.
+		httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+	}
+
+	// TODO: Test that an expired token (past TTL) triggers a fresh token fetch.
+	// This requires injecting a time abstraction (e.g., TimeProvider) into the service
+	// so tests can advance the clock past the cache TTL without waiting real time.
+	// Tracked as a follow-up refactor: inject TimeProvider into UserManagementService.
+
+	// TODO: Test ListUsersAsync success path (returns populated list).
+	// TODO: Test AssignRolesAsync success path (roles assigned, returns true).
+	// TODO: Test RemoveRolesAsync success path (roles removed, returns true).
+	// TODO: Test Auth0 API error → ResultErrorCode.ExternalService for all methods.
+	// These paths require UserManagementService to be refactored to accept an injectable
+	// IManagementApiClientFactory (or HttpClientManagementConnection), so that
+	// ManagementApiClient's HTTP calls can be intercepted in unit tests.
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ──────────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	///   Minimal <see cref="HttpMessageHandler" /> that delegates to a synchronous lambda.
+	/// </summary>
+	private sealed class FakeHttpMessageHandler(
+		Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request,
+			CancellationToken cancellationToken)
+			=> Task.FromResult(handler(request));
+	}
+}


### PR DESCRIPTION
## Summary

Working as Gimli (Test Engineer)

Closes #141

Adds comprehensive unit tests for the Admin User Management feature:

### Domain.Tests — Handler tests (`tests/Domain.Tests/Features/Admin/`)

- **ListUsersQueryHandlerTests** — success path, empty result, pagination forwarding, search-term filtering (email + name), service-failure propagation
- **AssignRoleCommandHandlerTests** — success path, audit entry persisted with correct data, `RoleAssignedEvent` published, service failure stops audit + event, validation error propagation
- **RemoveRoleCommandHandlerTests** — success path, audit entry with `"removed"` action, `RoleRemovedEvent` published, user-not-found and API error paths

### Web.Tests — Service tests (`tests/Web.Tests/Services/UserManagementServiceTests.cs`)

- **Input validation** — `AssignRolesAsync` / `RemoveRolesAsync` / `GetUserByIdAsync` with empty/whitespace userId → `ResultErrorCode.Validation`
- **Empty roles lists** — return `Ok(true)` immediately without calling Auth0 or `IHttpClientFactory`
- **M2M token caching** — cache-hit suppresses `IHttpClientFactory` call; pre-cached token completely skips token fetch

All mocks use NSubstitute. Naming follows `MethodName_Scenario_ExpectedResult`.

### Notes / Limitations

- **No standalone `RoleChangeAuditHandler`**: Audit behaviour is implemented inline inside the command handlers. Tests cover it via `IAuditLogRepository` call assertions in the command-handler test classes.
- **`UserManagementService` full API paths** (list success, assign/remove success, user-not-found): `UserManagementService` directly instantiates `ManagementApiClient` with a hardcoded connection, so Management API HTTP calls cannot be intercepted in unit tests. These paths require either integration tests against a real/staged Auth0 tenant **or** a refactor to inject an `IManagementApiClientFactory` / `HttpClientManagementConnection`. Documented with TODO comments in the service test file.
- **Expired-token refresh**: also requires a `TimeProvider` injection for clock control in tests. Documented with a TODO comment.

⚠️ This task was flagged as 'needs review' — please have a squad member review before merging.