### PR TITLE
feat: RoleBadge component for admin user roles (#138)

### DIFF
--- a/.squad/agents/sam/history.md
+++ b/.squad/agents/sam/history.md
@@ -743,3 +743,19 @@ set the proper config key.
 - Implementation quality is high — just need architecture convention fix
 
 **Pattern Established:** When naming classes, respect team conventions enforced by Architecture.Tests. If a class violates naming patterns (e.g., `*Repository` but doesn't implement `IRepository<T>`), rename it to reflect its true purpose (`*Writer`, `*Service`, etc.) rather than forcing the pattern.
+
+## Learnings — Issue #149 (Labels Domain Model)
+
+**Date:** 2026-04-01
+**Branch:** squad/149-labels-domain-model
+**PR:** #168
+
+### What was done
+Added `Labels` as `List<string>` to `Issue` model and `IReadOnlyList<string>` to `IssueDto` positional record. Updated `IssueMapper` (both ToDto and ToModel), `IssueConfiguration` (EF Core Mongo `builder.Property(i => i.Labels)`), `IssueDto.Empty`, and all 5 test helper `CreateTestIssueDto()` methods across Domain.Tests, Web.Tests, and Web.Tests.Bunit.
+
+### Key decisions
+- Appended `Labels` **after** `VotedBy` in the positional record to avoid breaking any existing positional construction calls — safest approach for positional records.
+- Used `[..dto.Labels]` spread syntax in `IssueMapper.ToModel` for consistent defensive copy (same pattern as VotedBy).
+
+### Pitfall encountered
+Local branch name mismatch: `git checkout -b squad/149-labels-domain-model` left HEAD on a different branch because `squad/149-labels-domain-model` already existed locally. Always verify `git branch --show-current` after checkout before committing.

--- a/src/Web/Components/Admin/Users/RoleBadge.razor
+++ b/src/Web/Components/Admin/Users/RoleBadge.razor
@@ -1,0 +1,31 @@
+@* RoleBadge.razor — component to render a single role as a colored pill *@
+
+@if (!string.IsNullOrWhiteSpace(RoleName))
+{
+	<span class="@GetBadgeClasses()" aria-label="Role: @RoleName">@RoleName</span>
+}
+
+@code {
+	/// <summary>
+	///   The role name to display.
+	/// </summary>
+	[Parameter]
+	public string? RoleName { get; set; }
+
+	private static readonly Dictionary<string, string> RoleColorMap = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["Admin"] = "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+		["Moderator"] = "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+		["User"] = "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+	};
+
+	private string GetBadgeClasses()
+	{
+		var baseClasses = "badge";
+		var colorClasses = RoleColorMap.TryGetValue(RoleName ?? string.Empty, out var css)
+			? css
+			: "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200";
+
+		return $"{baseClasses} {colorClasses}";
+	}
+}


### PR DESCRIPTION
Closes #138

Working as Legolas (Frontend Developer)

## Summary
Adds `RoleBadge.razor` to `src/Web/Components/Admin/Users/` — a leaf Blazor component that renders a single role name as a color-coded pill badge.

## Changes
- **New:** `src/Web/Components/Admin/Users/RoleBadge.razor`
  - Accepts `string? RoleName` parameter
  - Color map: `Admin` → red, `Moderator` → orange, `User` → blue, unknown → grey (dark-mode variants included)
  - Uses project-level `.badge` Tailwind utility class (rounded-full pill, xs font, px-2.5 py-0.5)
  - Renders nothing when `RoleName` is null/empty
  - `aria-label="Role: {name}"` for accessibility
  - `static readonly Dictionary` for easy color extension

## Acceptance Criteria
- [x] `RoleBadge.razor` accepts `string RoleName` parameter
- [x] Color scheme: Admin → red, Moderator → orange, User → blue, unknown → grey
- [x] Renders as a `<span>` pill (via .badge utility)
- [x] Multiple badges inline with `gap-1` (parent wraps in `flex flex-wrap gap-1`)
- [x] Accessible: `aria-label="Role: {name}"`
- [x] Handles null/empty gracefully (renders nothing)