### PR TITLE
chore: remove stray CI status files

### DIFF
--- a/ci_status.json
+++ b/ci_status.json
@@ -1,1 +1,0 @@
-{"conclusion":"cancelled","status":"completed"}

--- a/ci_status2.json
+++ b/ci_status2.json
@@ -1,1 +1,0 @@
-{"conclusion":"success","status":"completed"}


### PR DESCRIPTION
Removes ci_status.json and ci_status2.json accidentally committed by automation tooling.

Closes no issue.