### PR TITLE
test: unit tests for AddLabelCommand, RemoveLabelCommand, and LabelService (#154)

### DIFF
--- a/tests/Domain.Tests/Features/Issues/Commands/AddLabelCommandHandlerTests.cs
+++ b/tests/Domain.Tests/Features/Issues/Commands/AddLabelCommandHandlerTests.cs
@@ -1,0 +1,134 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     AddLabelCommandHandlerTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain.Tests
+// =======================================================
+
+using Domain.Features.Issues.Commands;
+
+namespace Domain.Tests.Features.Issues.Commands;
+
+/// <summary>
+///   Unit tests for AddLabelCommandHandler.
+/// </summary>
+public sealed class AddLabelCommandHandlerTests
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly IMediator _mediator;
+	private readonly AddLabelCommandHandler _handler;
+
+	public AddLabelCommandHandlerTests()
+	{
+		_repository = Substitute.For<IRepository<Issue>>();
+		_mediator = Substitute.For<IMediator>();
+		_handler = new AddLabelCommandHandler(
+			_repository,
+			_mediator,
+			new NullLogger<AddLabelCommandHandler>());
+	}
+
+	[Fact]
+	public async Task Handle_WithValidLabelAndIssueWithRoomForMore_AddsLabel()
+	{
+		// Arrange
+		var issueId = ObjectId.GenerateNewId().ToString();
+		var issue = new Issue
+		{
+			Id = ObjectId.Parse(issueId),
+			Title = "Test Issue",
+			Labels = ["alpha", "beta", "gamma"]
+		};
+
+		_repository.GetByIdAsync(issueId, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(issue));
+
+		_repository.UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => Result.Ok(callInfo.Arg<Issue>()));
+
+		var command = new AddLabelCommand(issueId, "delta");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeNull();
+		result.Value!.Labels.Should().Contain("delta");
+		await _repository.Received(1).UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_WithDuplicateLabel_ReturnsSuccessWithoutChange()
+	{
+		// Arrange
+		var issueId = ObjectId.GenerateNewId().ToString();
+		var issue = new Issue
+		{
+			Id = ObjectId.Parse(issueId),
+			Title = "Test Issue",
+			Labels = ["bug", "feature"]
+		};
+
+		_repository.GetByIdAsync(issueId, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(issue));
+
+		var command = new AddLabelCommand(issueId, "bug");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeNull();
+		await _repository.DidNotReceive().UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_WhenIssueHasTenLabels_ReturnsValidationError()
+	{
+		// Arrange
+		var issueId = ObjectId.GenerateNewId().ToString();
+		var issue = new Issue
+		{
+			Id = ObjectId.Parse(issueId),
+			Title = "Test Issue",
+			Labels = ["l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "l9", "l10"]
+		};
+
+		_repository.GetByIdAsync(issueId, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(issue));
+
+		var command = new AddLabelCommand(issueId, "l11");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		await _repository.DidNotReceive().UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_WhenIssueNotFound_ReturnsNotFoundError()
+	{
+		// Arrange
+		var issueId = ObjectId.GenerateNewId().ToString();
+
+		_repository.GetByIdAsync(issueId, Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<Issue>("Issue not found", ResultErrorCode.NotFound));
+
+		var command = new AddLabelCommand(issueId, "bug");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.NotFound);
+		await _repository.DidNotReceive().UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Domain.Tests/Features/Issues/Commands/RemoveLabelCommandHandlerTests.cs
+++ b/tests/Domain.Tests/Features/Issues/Commands/RemoveLabelCommandHandlerTests.cs
@@ -1,0 +1,108 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     RemoveLabelCommandHandlerTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain.Tests
+// =======================================================
+
+using Domain.Features.Issues.Commands;
+
+namespace Domain.Tests.Features.Issues.Commands;
+
+/// <summary>
+///   Unit tests for RemoveLabelCommandHandler.
+/// </summary>
+public sealed class RemoveLabelCommandHandlerTests
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly IMediator _mediator;
+	private readonly RemoveLabelCommandHandler _handler;
+
+	public RemoveLabelCommandHandlerTests()
+	{
+		_repository = Substitute.For<IRepository<Issue>>();
+		_mediator = Substitute.For<IMediator>();
+		_handler = new RemoveLabelCommandHandler(
+			_repository,
+			_mediator,
+			new NullLogger<RemoveLabelCommandHandler>());
+	}
+
+	[Fact]
+	public async Task Handle_WithExistingLabel_RemovesLabel()
+	{
+		// Arrange
+		var issueId = ObjectId.GenerateNewId().ToString();
+		var issue = new Issue
+		{
+			Id = ObjectId.Parse(issueId),
+			Title = "Test Issue",
+			Labels = ["bug", "feature", "urgent"]
+		};
+
+		_repository.GetByIdAsync(issueId, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(issue));
+
+		_repository.UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => Result.Ok(callInfo.Arg<Issue>()));
+
+		var command = new RemoveLabelCommand(issueId, "feature");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeNull();
+		result.Value!.Labels.Should().NotContain("feature");
+		await _repository.Received(1).UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_WithAbsentLabel_ReturnsSuccessWithoutChange()
+	{
+		// Arrange
+		var issueId = ObjectId.GenerateNewId().ToString();
+		var issue = new Issue
+		{
+			Id = ObjectId.Parse(issueId),
+			Title = "Test Issue",
+			Labels = ["bug"]
+		};
+
+		_repository.GetByIdAsync(issueId, Arg.Any<CancellationToken>())
+			.Returns(Result.Ok(issue));
+
+		var command = new RemoveLabelCommand(issueId, "nonexistent");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeNull();
+		await _repository.DidNotReceive().UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Handle_WhenIssueNotFound_ReturnsNotFoundError()
+	{
+		// Arrange
+		var issueId = ObjectId.GenerateNewId().ToString();
+
+		_repository.GetByIdAsync(issueId, Arg.Any<CancellationToken>())
+			.Returns(Result.Fail<Issue>("Issue not found", ResultErrorCode.NotFound));
+
+		var command = new RemoveLabelCommand(issueId, "bug");
+
+		// Act
+		var result = await _handler.Handle(command, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.NotFound);
+		await _repository.DidNotReceive().UpdateAsync(Arg.Any<Issue>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Domain.Tests/Features/Issues/Queries/GetLabelSuggestionsQueryHandlerTests.cs
+++ b/tests/Domain.Tests/Features/Issues/Queries/GetLabelSuggestionsQueryHandlerTests.cs
@@ -1,0 +1,84 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GetLabelSuggestionsQueryHandlerTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Domain.Tests
+// =======================================================
+
+using Domain.Features.Issues;
+using Domain.Features.Issues.Queries;
+
+namespace Domain.Tests.Features.Issues.Queries;
+
+/// <summary>
+///   Unit tests for GetLabelSuggestionsQueryHandler.
+/// </summary>
+public sealed class GetLabelSuggestionsQueryHandlerTests
+{
+	private readonly ILabelService _labelService;
+	private readonly GetLabelSuggestionsQueryHandler _handler;
+
+	public GetLabelSuggestionsQueryHandlerTests()
+	{
+		_labelService = Substitute.For<ILabelService>();
+		_handler = new GetLabelSuggestionsQueryHandler(
+			_labelService,
+			new NullLogger<GetLabelSuggestionsQueryHandler>());
+	}
+
+	[Fact]
+	public async Task Handle_WithMatchingLabels_ReturnsSortedDistinctResults()
+	{
+		// Arrange
+		IReadOnlyList<string> suggestions = ["bug", "bug-fix", "buggy"];
+		_labelService.GetSuggestionsAsync("bug", Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(suggestions);
+
+		var query = new GetLabelSuggestionsQuery("bug");
+
+		// Act
+		var result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeNull();
+		result.Value!.Should().BeEquivalentTo(["bug", "bug-fix", "buggy"]);
+	}
+
+	[Fact]
+	public async Task Handle_WithNoMatches_ReturnsEmptyList()
+	{
+		// Arrange
+		IReadOnlyList<string> empty = [];
+		_labelService.GetSuggestionsAsync("xyz", Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(empty);
+
+		var query = new GetLabelSuggestionsQuery("xyz");
+
+		// Act
+		var result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		result.Value.Should().NotBeNull();
+		result.Value!.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Handle_WithEmptyPrefix_ReturnsValidationFailure()
+	{
+		// Arrange
+		var query = new GetLabelSuggestionsQuery(string.Empty);
+
+		// Act
+		var result = await _handler.Handle(query, CancellationToken.None);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.ErrorCode.Should().Be(ResultErrorCode.Validation);
+		await _labelService.DidNotReceive()
+			.GetSuggestionsAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Web.Tests/Services/LabelServiceTests.cs
+++ b/tests/Web.Tests/Services/LabelServiceTests.cs
@@ -1,0 +1,109 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     LabelServiceTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Web.Tests
+// =======================================================
+
+using Domain.Models;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Web.Services;
+
+namespace Web.Tests.Services;
+
+/// <summary>
+///   Unit tests for LabelService suggestion logic.
+/// </summary>
+public sealed class LabelServiceTests
+{
+	private readonly IRepository<Issue> _repository;
+	private readonly LabelService _sut;
+
+	public LabelServiceTests()
+	{
+		_repository = Substitute.For<IRepository<Issue>>();
+		_sut = new LabelService(_repository, new NullLogger<LabelService>());
+	}
+
+	[Fact]
+	public async Task GetSuggestionsAsync_WithMatchingPrefix_ReturnsSuggestions()
+	{
+		// Arrange
+		var issues = new List<Issue>
+		{
+			new() { Labels = ["bug", "bugfix", "feature"] },
+			new() { Labels = ["bug", "backend"] }
+		};
+
+		_repository.GetAllAsync(Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IEnumerable<Issue>>(issues));
+
+		// Act
+		var result = await _sut.GetSuggestionsAsync("bu");
+
+		// Assert
+		result.Should().NotBeEmpty();
+		result.Should().OnlyContain(l => l.StartsWith("bu", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task GetSuggestionsAsync_WithEmptyPrefix_ReturnsAllLabels()
+	{
+		// Arrange
+		var issues = new List<Issue>
+		{
+			new() { Labels = ["alpha", "beta"] },
+			new() { Labels = ["gamma"] }
+		};
+
+		_repository.GetAllAsync(Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IEnumerable<Issue>>(issues));
+
+		// Act
+		var result = await _sut.GetSuggestionsAsync(string.Empty);
+
+		// Assert
+		result.Should().HaveCount(3);
+		result.Should().Contain("alpha");
+		result.Should().Contain("beta");
+		result.Should().Contain("gamma");
+	}
+
+	[Fact]
+	public async Task GetSuggestionsAsync_WhenRepositoryReturnsNoIssues_ReturnsEmpty()
+	{
+		// Arrange
+		_repository.GetAllAsync(Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IEnumerable<Issue>>([]));
+
+		// Act
+		var result = await _sut.GetSuggestionsAsync("bug");
+
+		// Assert
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetSuggestionsAsync_RespectsMaxResults()
+	{
+		// Arrange
+		var labels = Enumerable.Range(1, 20).Select(i => $"bug-{i:D2}").ToList();
+		var issues = new List<Issue>
+		{
+			new() { Labels = labels }
+		};
+
+		_repository.GetAllAsync(Arg.Any<CancellationToken>())
+			.Returns(Result.Ok<IEnumerable<Issue>>(issues));
+
+		// Act
+		var result = await _sut.GetSuggestionsAsync("bug", maxResults: 5);
+
+		// Assert
+		result.Should().HaveCount(5);
+	}
+}


### PR DESCRIPTION
Closes #154
Working as Gimli (Tester)

## Summary

Adds unit tests for the label feature as specified in issue #154.

### Tests added

- tests/Domain.Tests/Features/Issues/Commands/AddLabelCommandHandlerTests.cs
- tests/Domain.Tests/Features/Issues/Commands/RemoveLabelCommandHandlerTests.cs
- tests/Domain.Tests/Features/Issues/Queries/GetLabelSuggestionsQueryHandlerTests.cs
- tests/Web.Tests/Services/LabelServiceTests.cs

### Gates verified locally
- Release build: clean
- Domain.Tests: 404 passed (10 new)
- Web.Tests: 361 passed (4 new)
- Architecture.Tests: 60 passed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>