### PR TITLE
docs: README, XML docs, and CONTRIBUTING updates for Labels feature (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ IssueTrackerApp is a full-stack web application for managing issues and tracking
 - **Status Tracking**: Track issues through configurable status workflows
 - **Category Organization**: Organize issues by customizable categories
 - **User Dashboard**: Personal analytics with stats cards, recent issues, and quick actions
+- **Labels**: Free-form tags (up to 10 per issue) for quick categorization. Add or remove labels via the `LabelInput` tag-input component on the create and edit forms; autocomplete suggestions are served by `GET /api/labels/suggestions?prefix={prefix}&max={max}`. Filter the issue list by one or more labels using the chip selectors on the index page or the `?label=bug,v2` URL parameter.
 - **Search & Filtering**: Debounced search, multi-filter support, pagination, and bookmarkable URLs
 
 ### Administration


### PR DESCRIPTION
Closes #156

Working as Frodo (Documentation Specialist)

## Summary

- **README.md**: Added a **Labels** bullet to the *Core Functionality* features section covering: free-form tags (max 10 per issue), the `LabelInput` component on create/edit forms, label filtering via chips or `?label=bug,v2` URL param, and the `GET /api/labels/suggestions` autocomplete endpoint.
- **XML doc comments**: All public types in the Labels slice (`AddLabelCommand`, `RemoveLabelCommand`, `ILabelService`, `GetLabelSuggestionsQuery`, `LabelService`, `LabelEndpoints`) already have complete `<summary>` comments consistent with the existing codebase style — no changes needed.
- **CONTRIBUTING.md**: No changes needed. The cross-layer service-interface pattern (`ILabelService` in Domain, implemented in Web) is already well-established by `IBulkOperationQueue`, `IUserManagementService`, and others, and is covered by the existing CQRS conventions section.

## Build

`dotnet build IssueTrackerApp.slnx -c Release` — **0 warnings, 0 errors**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>