### PR TITLE
test: bUnit tests for LabelInput component and label filter chips (#153)

### DIFF
--- a/tests/Web.Tests.Bunit/BunitTestBase.cs
+++ b/tests/Web.Tests.Bunit/BunitTestBase.cs
@@ -285,4 +285,9 @@ internal class FakeNavigationManager : NavigationManager
 	{
 		Uri = ToAbsoluteUri(uri).ToString();
 	}
+
+	protected override void NavigateToCore(string uri, NavigationOptions options)
+	{
+		Uri = ToAbsoluteUri(uri).ToString();
+	}
 }

--- a/tests/Web.Tests.Bunit/Components/Pages/Issues/LabelFilterChipTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Pages/Issues/LabelFilterChipTests.cs
@@ -1,0 +1,127 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     LabelFilterChipTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Web.Tests.Bunit
+// =======================================================
+
+namespace Web.Tests.Bunit.Components.Pages.Issues;
+
+using IssuesIndexPage = Web.Components.Pages.Issues.Index;
+
+/// <summary>
+///   Tests for label filter chip behaviour on the Issues Index page.
+/// </summary>
+public sealed class LabelFilterChipTests : BunitTestBase
+{
+	/// <summary>
+	///   Builds a <see cref="PagedResult{T}"/> containing the supplied issues.
+	/// </summary>
+	private static PagedResult<IssueDto> BuildPagedResult(params IssueDto[] issues) =>
+		PagedResult<IssueDto>.Create(issues, issues.Length, 1, 20);
+
+	/// <summary>
+	///   Creates a test issue that carries the given labels.
+	/// </summary>
+	private static IssueDto CreateIssueWithLabels(params string[] labels) =>
+		CreateTestIssue() with { Labels = labels.ToList() };
+
+	#region Label chip on issue card
+
+	[Fact]
+	public async Task LabelFilterChip_WhenLabelClicked_AddsToFilterState()
+	{
+		// Arrange — return one issue whose card has a "priority" label chip
+		var issue = CreateIssueWithLabels("priority");
+		IssueService.SearchIssuesAsync(Arg.Any<IssueSearchRequest>(), Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult(Result.Ok(BuildPagedResult(issue))));
+
+		var cut = Render<IssuesIndexPage>();
+
+		// Wait for the async OnInitializedAsync to complete and issues to appear
+		await cut.WaitForStateAsync(
+			() => cut.Markup.Contains("priority"),
+			TimeSpan.FromSeconds(3));
+
+		// Act — click the label chip on the issue card
+		var labelChip = cut.Find("button[title='Filter by this label']");
+		await cut.InvokeAsync(() => labelChip.Click());
+
+		// Assert — the active-filters bar is now visible
+		await cut.WaitForStateAsync(
+			() => cut.Markup.Contains("Active label filters:"),
+			TimeSpan.FromSeconds(2));
+
+		cut.Markup.Should().Contain("Active label filters:");
+		cut.Markup.Should().Contain("priority");
+	}
+
+	#endregion
+
+	#region Active filter chip removal
+
+	[Fact]
+	public async Task ActiveFilter_WhenXClicked_RemovesFilter()
+	{
+		// Arrange — navigate to a URL that pre-populates the label filter via query params
+		Services.GetRequiredService<NavigationManager>().NavigateTo("/?label=bug");
+
+		// SearchIssuesAsync is called on init; return empty so the page loads quickly
+		IssueService.SearchIssuesAsync(Arg.Any<IssueSearchRequest>(), Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult(Result.Ok(PagedResult<IssueDto>.Empty)));
+
+		var cut = Render<IssuesIndexPage>();
+
+		// Wait for the active-label-filter bar to be rendered (parsed from query params)
+		await cut.WaitForStateAsync(
+			() => cut.Markup.Contains("Active label filters:"),
+			TimeSpan.FromSeconds(3));
+
+		// Act — click the "bug" filter button (which also contains the × SVG)
+		var filterChip = cut.Find("button.rounded-full");
+		await cut.InvokeAsync(() => filterChip.Click());
+
+		// Assert — active filter section is gone
+		await cut.WaitForStateAsync(
+			() => !cut.Markup.Contains("Active label filters:"),
+			TimeSpan.FromSeconds(2));
+
+		cut.Markup.Should().NotContain("Active label filters:");
+	}
+
+	[Fact]
+	public async Task ActiveFilter_ClearAll_RemovesAllFilters()
+	{
+		// Arrange — pre-populate two label filters via URL query params
+		Services.GetRequiredService<NavigationManager>().NavigateTo("/?label=bug,feature");
+
+		IssueService.SearchIssuesAsync(Arg.Any<IssueSearchRequest>(), Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult(Result.Ok(PagedResult<IssueDto>.Empty)));
+
+		var cut = Render<IssuesIndexPage>();
+
+		// Wait for the active-label-filter bar to be rendered
+		await cut.WaitForStateAsync(
+			() => cut.Markup.Contains("Active label filters:"),
+			TimeSpan.FromSeconds(3));
+
+		// Both labels should appear as active chips
+		cut.Markup.Should().Contain("bug");
+		cut.Markup.Should().Contain("feature");
+
+		// Act — click "Clear all"
+		var clearAll = cut.Find("button.underline");
+		await cut.InvokeAsync(() => clearAll.Click());
+
+		// Assert — active filter section is gone
+		await cut.WaitForStateAsync(
+			() => !cut.Markup.Contains("Active label filters:"),
+			TimeSpan.FromSeconds(2));
+
+		cut.Markup.Should().NotContain("Active label filters:");
+	}
+
+	#endregion
+}

--- a/tests/Web.Tests.Bunit/Components/Shared/LabelInputTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Shared/LabelInputTests.cs
@@ -1,0 +1,226 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     LabelInputTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Web.Tests.Bunit
+// =======================================================
+
+using Web.Components.Shared;
+
+namespace Web.Tests.Bunit.Components.Shared;
+
+/// <summary>
+///   Tests for the LabelInput component.
+/// </summary>
+public sealed class LabelInputTests : BunitTestBase
+{
+	#region Render Tests
+
+	[Fact]
+	public void Renders_WithNoLabels_ShowsPlaceholderText()
+	{
+		// Arrange & Act
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, [])
+		);
+
+		// Assert
+		var input = cut.Find("input#label-input");
+		input.Should().NotBeNull();
+		input.GetAttribute("placeholder").Should().Contain("Add labels");
+	}
+
+	[Fact]
+	public void Renders_WithLabels_ShowsPillsForEachLabel()
+	{
+		// Arrange & Act
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, ["bug", "v2"])
+		);
+
+		// Assert — each label pill is a <span> with the label text
+		var pills = cut.FindAll("span.rounded");
+		pills.Should().HaveCount(2);
+		cut.Markup.Should().Contain("bug");
+		cut.Markup.Should().Contain("v2");
+	}
+
+	[Fact]
+	public async Task RemoveButton_WhenClicked_RemovesLabel()
+	{
+		// Arrange
+		List<string>? capturedLabels = null;
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, ["bug", "v2"])
+			.Add(p => p.LabelsChanged,
+				EventCallback.Factory.Create<List<string>>(this, list => capturedLabels = list))
+		);
+
+		// Act — click the remove button for "bug"
+		var removeButton = cut.Find("button[aria-label='Remove label bug']");
+		await cut.InvokeAsync(() => removeButton.Click());
+
+		// Assert
+		capturedLabels.Should().NotBeNull();
+		capturedLabels.Should().NotContain("bug");
+		capturedLabels.Should().Contain("v2");
+	}
+
+	[Fact]
+	public async Task Input_WhenEnterPressed_AddsLabel()
+	{
+		// Arrange
+		List<string>? capturedLabels = null;
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, [])
+			.Add(p => p.LabelsChanged,
+				EventCallback.Factory.Create<List<string>>(this, list => capturedLabels = list))
+		);
+
+		var input = cut.Find("input#label-input");
+
+		// Act — set input value then press Enter
+		await cut.InvokeAsync(() => input.Input("feature"));
+		await cut.InvokeAsync(() => input.KeyDown(Key.Enter));
+
+		// Assert
+		capturedLabels.Should().NotBeNull();
+		capturedLabels.Should().Contain("feature");
+	}
+
+	[Fact]
+	public async Task Input_WhenCommaTyped_AddsLabel()
+	{
+		// Arrange
+		List<string>? capturedLabels = null;
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, [])
+			.Add(p => p.LabelsChanged,
+				EventCallback.Factory.Create<List<string>>(this, list => capturedLabels = list))
+		);
+
+		var input = cut.Find("input#label-input");
+
+		// Act — simulate typing "bug" then pressing the comma key
+		await cut.InvokeAsync(() => input.Input("bug"));
+		await cut.InvokeAsync(() => input.KeyDown(","));
+
+		// Assert
+		capturedLabels.Should().NotBeNull();
+		capturedLabels.Should().Contain("bug");
+	}
+
+	[Fact]
+	public void Input_AtMaxLabels_HidesInput()
+	{
+		// Arrange — 10 labels (== MaxLabels default)
+		var labels = Enumerable.Range(1, 10).Select(i => $"label-{i}").ToList();
+
+		// Act
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, labels)
+		);
+
+		// Assert
+		cut.FindAll("input#label-input").Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Input_AtMaxLabels_ShowsWarning()
+	{
+		// Arrange — 10 labels (== MaxLabels default)
+		var labels = Enumerable.Range(1, 10).Select(i => $"label-{i}").ToList();
+
+		// Act
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, labels)
+		);
+
+		// Assert
+		var warning = cut.Find("p[role='status']");
+		warning.Should().NotBeNull();
+		warning.TextContent.Should().Contain("Maximum of 10 labels reached");
+	}
+
+	[Fact]
+	public async Task Input_WhenDuplicateLabel_DoesNotAdd()
+	{
+		// Arrange
+		var callCount = 0;
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, ["bug"])
+			.Add(p => p.LabelsChanged,
+				EventCallback.Factory.Create<List<string>>(this, _ => callCount++))
+		);
+
+		var input = cut.Find("input#label-input");
+
+		// Act — attempt to add "bug" again (case-insensitive duplicate)
+		await cut.InvokeAsync(() => input.Input("bug"));
+		await cut.InvokeAsync(() => input.KeyDown(Key.Enter));
+
+		// Assert — callback should NOT have been fired (duplicate is silently ignored)
+		callCount.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task Autocomplete_WhenTextTyped_CallsLabelService()
+	{
+		// Arrange — override mock to return suggestions
+		LabelService.GetSuggestionsAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<IReadOnlyList<string>>(["bug", "feature", "v2"]));
+
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, [])
+		);
+
+		var input = cut.Find("input#label-input");
+
+		// Act — type enough characters to trigger a suggestion fetch
+		await cut.InvokeAsync(() => input.Input("fea"));
+
+		// Wait for the 300 ms debounce to elapse and the async fetch to complete
+		await Task.Delay(500);
+
+		// Assert
+		await LabelService.Received(1)
+			.GetSuggestionsAsync(Arg.Is("fea"), Arg.Any<int>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Autocomplete_WhenSuggestionClicked_AddsLabel()
+	{
+		// Arrange — override mock to return suggestions
+		LabelService.GetSuggestionsAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<IReadOnlyList<string>>(["feature", "bug", "v2"]));
+
+		List<string>? capturedLabels = null;
+		var cut = Render<LabelInput>(parameters => parameters
+			.Add(p => p.Labels, [])
+			.Add(p => p.LabelsChanged,
+				EventCallback.Factory.Create<List<string>>(this, list => capturedLabels = list))
+		);
+
+		var input = cut.Find("input#label-input");
+
+		// Act — type text to trigger autocomplete
+		await cut.InvokeAsync(() => input.Input("fea"));
+
+		// Wait for debounce + StateHasChanged re-render
+		await cut.WaitForStateAsync(
+			() => cut.FindAll("button[role='option']").Count > 0,
+			TimeSpan.FromSeconds(2));
+
+		// Click the first suggestion
+		var suggestion = cut.Find("button[role='option']");
+		await cut.InvokeAsync(() => suggestion.Click());
+
+		// Assert
+		capturedLabels.Should().NotBeNull();
+		capturedLabels.Should().Contain("feature");
+	}
+
+	#endregion
+}


### PR DESCRIPTION
## Summary

Closes #153

Working as Gimli (Tester)

## Changes

### New test files
- **`tests/Web.Tests.Bunit/Components/Shared/LabelInputTests.cs`** — 10 tests for the `LabelInput` component:
  - Renders placeholder text when no labels
  - Renders pills for each label
  - Remove-button click fires `LabelsChanged` with label removed
  - Enter key adds label and fires callback
  - Comma key adds label
  - Hides input at max labels (10)
  - Shows warning at max labels
  - Duplicate label is silently ignored
  - Typing triggers `ILabelService.GetSuggestionsAsync` after debounce
  - Clicking a suggestion adds the label

- **`tests/Web.Tests.Bunit/Components/Pages/Issues/LabelFilterChipTests.cs`** — 3 tests for label filter chip behaviour on the Issues Index page:
  - Clicking a label chip on an issue card shows `Active label filters:` bar
  - Clicking the active filter chip × button removes that filter
  - Clicking `Clear all` removes all label filters

### Bug fix
- **`BunitTestBase.cs`** — Added `NavigateToCore(string, NavigationOptions)` override to `FakeNavigationManager` so URL updates from `UpdateQueryParameters()` in Index.razor work correctly in bUnit context.

## Test counts
| Suite | Before | After |
|-------|--------|-------|
| bUnit | 703 | **716** |
| Domain | 404 | 404 |
| Architecture | 60 | 60 |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>