### PR TITLE
docs: release blog posts for v0.5.0 and v0.6.0

### DIFF
--- a/docs/blog/2026-04-02-release-v0-5-0.md
+++ b/docs/blog/2026-04-02-release-v0-5-0.md
@@ -1,0 +1,183 @@
+---
+title: "Release v0.5.0 — Admin User Management"
+date: 2026-04-02
+author: Matthew Paulosky
+tags: [release, v0.5.0, admin, auth0, blazor]
+summary: "v0.5.0 ships the Admin User Management feature: Auth0 Management API integration, /admin/users page with UserListTable, RoleBadge, EditUserRolesModal, UserAuditLogPanel, full CQRS handlers, and comprehensive test coverage."
+---
+
+## Summary
+
+**v0.5.0 is now live.** This release delivers **complete Admin User Management capabilities**, enabling system administrators to manage Auth0 users, assign roles, and audit user actions from a dedicated admin interface. The new `/admin/users` page provides a searchable, paginated table of all users with in-place role management, audit history, and role badges. Under the hood, we've integrated the Auth0 Management API, implemented a token-caching strategy to respect rate limits, and built a full CQRS command/query layer with domain models and comprehensive test coverage.
+
+## What's New
+
+### Features
+
+The v0.5.0 feature set introduces **production-grade admin user management with Auth0 integration**:
+
+- **Auth0 Management API Integration** (#130, PR #146): Architecture Decision Record (ADR) documents the evaluation of Auth0 SDK options, rate-limiting strategy, and token caching. `UserManagementService` wraps the Auth0 Management API behind `IUserManagementService`, enabling safe, testable access to user and role data.
+- **Admin-Only Authorization Policy** (#135, PR #157): New `AdminPolicy` authorization policy guards all `/admin/users` routes. Role-based middleware enforces Admin role checks; `Auth0ClaimsTransformation` remaps Auth0 role claims into the .NET `ClaimsPrincipal`.
+- **Domain Models & CQRS Handlers** (#131, #132, #134, PR merged): New `AdminUser` model and `UserAuditEntry` record represent user state. Full MediatR command/query layer: `GetUsersQuery` (paginated listing), `GetUserQuery` (single user), `AssignRoleCommand`, `RemoveRoleCommand`. All handlers follow naming conventions enforced by architecture tests.
+- **/admin/users Page Scaffold** (#136): New admin users page under `/admin/users`; nav entry added to Admin section; admin dashboard card links to user management.
+- **UserListTable Component** (#137): Paginated Blazor table displaying Auth0 users with columns for username, email, roles, and action buttons. Supports sorting and pagination through Blazor's component lifecycle.
+- **RoleBadge Component** (#138, PR #167): Color-coded role pill component (Admin = red, User = blue, Guest = gray). Reusable across the admin interface and issue details.
+- **EditUserRolesModal Component** (#139, PR #171): In-place role assignment/revocation modal. Loads current user roles, renders role checkboxes, and persists changes via `AssignRoleCommand` and `RemoveRoleCommand`. Integrates with `IUserManagementService`.
+- **UserAuditLogPanel Component** (#140, PR #170): Per-user audit history panel showing timestamp, action (e.g., "Role Added", "Role Removed"), and actor (admin user who made the change).
+- **Comprehensive Test Coverage** (#141, #142, #143, PR #169, #174): `UserManagementServiceTests` verify Auth0 API interactions; admin MediatR handler tests cover CQRS command/query flows; admin authorization policy integration tests; bUnit tests for all admin UI components (UserListTable, RoleBadge, EditUserRolesModal, UserAuditLogPanel).
+- **Auth0 CI/CD Secrets** (#145): Management API secrets wired into GitHub Actions and Aspire AppHost for both local dev and CI environments. Secure secret management ensures production deployments have valid Auth0 credentials.
+- **Documentation** (#144, #166): v0.5.0 feature guide in docs/; blog catch-up for v0.3.0 and v0.4.0; Release Notes section added to docs/index.html.
+
+### Architecture Deep Dive
+
+#### Auth0 Management API Integration
+
+The `UserManagementService` wraps the Auth0 Management API SDK:
+
+```csharp
+public sealed class UserManagementService : IUserManagementService
+{
+    private readonly ManagementApiClient _client;
+
+    public UserManagementService(ManagementApiClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<IReadOnlyList<AdminUser>> GetUsersAsync(int page = 0, int pageSize = 50, CancellationToken ct = default)
+    {
+        var users = await _client.Users.GetAllAsync(
+            new GetUsersRequest { Page = page, PerPage = pageSize },
+            cancellationToken: ct
+        );
+        return users.Select(u => new AdminUser(u.UserId, u.Email, u.Name, u.Roles?.ToList() ?? [])).ToList();
+    }
+
+    public async Task<Result<Unit>> AssignRoleAsync(string userId, string roleId, CancellationToken ct)
+    {
+        try
+        {
+            await _client.Users.AssignRolesAsync(userId, new AssignRolesRequest { Roles = [roleId] }, cancellationToken: ct);
+            return Result<Unit>.Success(Unit.Value);
+        }
+        catch (ApiException ex)
+        {
+            return Result<Unit>.Failure(ResultErrorCode.ExternalService);
+        }
+    }
+}
+```
+
+#### Admin Authorization Policy
+
+The `AdminPolicy` is registered in `Program.cs` and guards all `/admin` routes:
+
+```csharp
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy("AdminPolicy", policy =>
+        policy.RequireRole("Admin")
+              .RequireAuthenticatedUser()
+    );
+```
+
+Route groups use the policy:
+
+```csharp
+var adminGroup = app.MapGroup("/admin/users")
+    .WithName("Admin")
+    .RequireAuthorization("AdminPolicy");
+```
+
+#### CQRS Command & Query Handlers
+
+Admin user queries and commands follow the domain CQRS pattern:
+
+```csharp
+public sealed class GetUsersQuery : IRequest<Result<PagedList<AdminUserDto>>>
+{
+    public required int Page { get; set; }
+    public required int PageSize { get; set; } = 50;
+}
+
+public sealed class GetUsersQueryHandler : IRequestHandler<GetUsersQuery, Result<PagedList<AdminUserDto>>>
+{
+    public async Task<Result<PagedList<AdminUserDto>>> Handle(GetUsersQuery request, CancellationToken ct)
+    {
+        var users = await _userManagementService.GetUsersAsync(request.Page, request.PageSize, ct);
+        return Result<PagedList<AdminUserDto>>.Success(
+            new PagedList<AdminUserDto>(
+                users.Select(u => new AdminUserDto(u.UserId, u.Email, u.Name, u.Roles)).ToList(),
+                request.Page,
+                request.PageSize,
+                users.Count
+            )
+        );
+    }
+}
+```
+
+#### Idempotent Role Assignment
+
+Role assignment and removal commands are idempotent: assigning a role twice or removing a role that doesn't exist returns success without side effects:
+
+```csharp
+public sealed class AssignRoleCommand : IRequest<Result<AdminUserDto>>
+{
+    public required string UserId { get; set; }
+    public required string RoleId { get; set; }
+}
+
+public sealed class AssignRoleCommandHandler : IRequestHandler<AssignRoleCommand, Result<AdminUserDto>>
+{
+    public async Task<Result<AdminUserDto>> Handle(AssignRoleCommand request, CancellationToken ct)
+    {
+        var result = await _userManagementService.AssignRoleAsync(request.UserId, request.RoleId, ct);
+        if (result.IsFailure) return Result<AdminUserDto>.Failure(result.Error);
+
+        var user = await _userManagementService.GetUserAsync(request.UserId, ct);
+        return Result<AdminUserDto>.Success(new AdminUserDto(user.UserId, user.Email, user.Name, user.Roles));
+    }
+}
+```
+
+#### Test Coverage
+
+- **UserManagementServiceTests**: Mock `ManagementApiClient` to verify user queries, role assignment, and error handling.
+- **Admin Handler Tests**: Verify CQRS command/query handlers return correct `Result<T>` types and audit entries are created.
+- **Authorization Integration Tests**: Verify `AdminPolicy` rejects non-admin users and accepts admin users.
+- **bUnit Component Tests**: Verify `UserListTable` renders user rows, `RoleBadge` displays correct colors, `EditUserRolesModal` toggles roles, `UserAuditLogPanel` shows audit history.
+
+---
+
+## How to Upgrade
+
+1. **From v0.4.0 → v0.5.0**: No breaking changes. Git pull, `dotnet restore`, `dotnet build`.
+2. **New Auth0 Secrets**: Set `Auth0:ManagementApiClientId` and `Auth0:ManagementApiClientSecret` in AppHost configuration and GitHub Actions secrets. Local dev defaults to unauthenticated mode (guest user only).
+3. **New Admin Routes**: Admin users page is available at `/admin/users` to authenticated Admin users only.
+4. **Admin Navigation**: Admin menu now includes a "User Management" link to the new `/admin/users` page.
+
+---
+
+## Performance & Security
+
+- **Token Caching**: Auth0 Management API tokens are cached in memory with a 5-minute TTL to minimize token requests and respect rate limits (10 req/sec default, 1M req/month).
+- **Rate-Limit Aware**: `UserManagementService` respects Auth0's rate-limit headers and backs off gracefully.
+- **Role-Based Access Control**: Only users with the "Admin" role can access `/admin/users`. Non-admin users receive a 403 Forbidden response.
+- **Audit Trail**: Every role assignment/revocation is recorded in the user audit log with timestamp and actor.
+
+---
+
+## What's Next
+
+With v0.5.0, the admin tier is ready for production. Upcoming work includes:
+
+- **Label Management**: Create, edit, delete custom labels for issues (v0.6.0)
+- **Bulk User Operations**: Bulk role assignment, bulk deactivation
+- **Advanced Reporting**: Admin dashboard with user activity trends, role distribution
+- **Audit Log Export**: Download full audit trail as CSV
+
+---
+
+**Release v0.5.0:** [Full Changelog](https://github.com/mpaulosky/IssueTrackerApp/compare/v0.4.0...v0.5.0)
+
+**Key Issues Closed:** [#130](https://github.com/mpaulosky/IssueTrackerApp/issues/130), [#131](https://github.com/mpaulosky/IssueTrackerApp/issues/131), [#132](https://github.com/mpaulosky/IssueTrackerApp/issues/132), [#134](https://github.com/mpaulosky/IssueTrackerApp/issues/134), [#135](https://github.com/mpaulosky/IssueTrackerApp/issues/135), [#136](https://github.com/mpaulosky/IssueTrackerApp/issues/136), [#137](https://github.com/mpaulosky/IssueTrackerApp/issues/137), [#138](https://github.com/mpaulosky/IssueTrackerApp/issues/138), [#139](https://github.com/mpaulosky/IssueTrackerApp/issues/139), [#140](https://github.com/mpaulosky/IssueTrackerApp/issues/140)

--- a/docs/blog/2026-04-02-release-v0-6-0.md
+++ b/docs/blog/2026-04-02-release-v0-6-0.md
@@ -1,0 +1,376 @@
+---
+title: "Release v0.6.0 — Labels Feature"
+date: 2026-04-02
+author: Matthew Paulosky
+tags: [release, v0.6.0, labels, cqrs, blazor, bunit]
+summary: "v0.6.0 ships the Labels feature: multi-value tag input with autocomplete, filter issues by label, AddLabelCommand/RemoveLabelCommand CQRS handlers, and 1,167 total tests passing."
+---
+
+## Summary
+
+**v0.6.0 is now live.** This release introduces a **flexible Labels feature** that enables team members to tag issues with custom labels, filter by label, and organize work across multiple dimensions. Each issue now supports multiple labels stored as `List<string>` on the Issue model. The new `LabelInput.razor` component provides a polished multi-value tag input with debounced autocomplete, making it seamless to add and remove labels. The Issues list supports URL-based label filtering with quick-filter chips above the table. Under the hood, `AddLabelCommand` and `RemoveLabelCommand` implement the CQRS pattern, and `ILabelService` aggregates distinct labels from existing issues for autocomplete suggestions. This release brings total test coverage to **1,167 tests** (up from 1,050 before Sprint 6).
+
+## What's New
+
+### Features
+
+The v0.6.0 feature set introduces **flexible, team-driven issue organization through labels**:
+
+- **Labels Domain Model** (#149, PR #168): Added `Labels` field (`List<string>`) to the `Issue` model, `IssueDto` (positional record), and `IssueMapper`. Both `Issue.Empty` and `IssueDto.Empty` updated to include an empty labels list.
+- **AddLabelCommand / RemoveLabelCommand** (#148, PR #173): CQRS command handlers under `Domain/Features/Issues/Commands/`. `AddLabelCommand` appends a label to an issue (no-op if duplicate); `RemoveLabelCommand` removes a label by value. Both publish `IssueUpdatedEvent` and return `Result<IssueDto>`. Architecture tests enforce naming conventions and handler placement.
+- **ILabelService & Label Endpoints** (#151, PR #175): `ILabelService` / `LabelService` aggregate distinct labels from all existing issues. New `GET /api/labels/suggestions?prefix={query}` endpoint returns matching label suggestions, guarded by `AdminPolicy`. Fixed `EmailQueueBackgroundService` timing flakiness in the same PR.
+- **Filter Issues by Label** (#150, PR #177): Issues list page now supports URL query parameters (`?label=bug,v2`) for label filtering. Quick-filter chips render above the issue list; clicking a chip toggles the filter. `NavigationManager` integration syncs the filter state to the URL for bookmarking and sharing.
+- **LabelInput.razor Component** (#152, #154, PR #178): Multi-value tag input with debounced autocomplete (300ms), comma or Enter to confirm tags, backspace-to-remove. Calls `ILabelService` for live suggestions dropdown. Used in Create Issue and Edit Issue forms.
+- **Architecture Tests** (#155, PR #176): 60 total architecture tests. Labels-specific tests verify `AddLabelCommand` / `RemoveLabelCommand` naming, handler placement in `Domain/Features/Issues/Commands/`, and that `LabelService` implements `ILabelService`.
+- **bUnit Component Tests** (#153, #142, PRs #174, #181): `LabelInputTests.cs` (10 tests) and `LabelFilterChipTests.cs` (3 tests). Fixed `FakeNavigationManager` override for `NavigateToCore(string, NavigationOptions)`. Total: 716 bUnit tests passing (up from 706 before Sprint 6).
+- **Documentation** (#156, PR #180): README Labels section, XML doc comments on all public `Label*` APIs, CONTRIBUTING notes for label workflow and conventions.
+
+### Architecture Deep Dive
+
+#### Labels Domain Model
+
+Labels are stored as a simple `List<string>` on the `Issue` model. MongoDB persists this as an array field, making queries efficient:
+
+```csharp
+public class Issue : IEntity
+{
+    public required ObjectId Id { get; set; }
+    public required string Title { get; set; }
+    public required string Description { get; set; }
+    public required ObjectId CreatedBy { get; set; }
+    public required DateTime CreatedAt { get; set; }
+    public required List<string> Labels { get; set; } = [];
+    // ... other fields
+}
+```
+
+`IssueDto` mirrors this structure:
+
+```csharp
+public sealed record IssueDto(
+    string Id,
+    string Title,
+    string Description,
+    string CreatedBy,
+    DateTime CreatedAt,
+    List<string> Labels,
+    // ... other fields
+)
+{
+    public static IssueDto Empty => new(
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        DateTime.MinValue,
+        [],
+        // ... empty values for other fields
+    );
+}
+```
+
+#### CQRS Label Commands
+
+Label operations follow the domain CQRS pattern with idempotent semantics:
+
+```csharp
+public sealed class AddLabelCommand : IRequest<Result<IssueDto>>
+{
+    public required ObjectId IssueId { get; set; }
+    public required string Label { get; set; }
+}
+
+public sealed class AddLabelCommandHandler : IRequestHandler<AddLabelCommand, Result<IssueDto>>
+{
+    public async Task<Result<IssueDto>> Handle(AddLabelCommand request, CancellationToken ct)
+    {
+        var issue = await _repository.GetByIdAsync(request.IssueId, ct);
+        if (issue == null) return Result<IssueDto>.Failure(IssueErrorCodes.NotFound);
+
+        // Idempotent: adding a duplicate label is a no-op
+        if (!issue.Labels.Contains(request.Label))
+        {
+            issue.Labels.Add(request.Label);
+            await _repository.UpdateAsync(issue, ct);
+
+            await _publisher.Publish(
+                new IssueUpdatedEvent { IssueId = issue.Id },
+                ct
+            );
+        }
+
+        return Result<IssueDto>.Success(_mapper.ToDto(issue));
+    }
+}
+```
+
+Similarly, `RemoveLabelCommand` safely removes a label:
+
+```csharp
+public sealed class RemoveLabelCommand : IRequest<Result<IssueDto>>
+{
+    public required ObjectId IssueId { get; set; }
+    public required string Label { get; set; }
+}
+
+public sealed class RemoveLabelCommandHandler : IRequestHandler<RemoveLabelCommand, Result<IssueDto>>
+{
+    public async Task<Result<IssueDto>> Handle(RemoveLabelCommand request, CancellationToken ct)
+    {
+        var issue = await _repository.GetByIdAsync(request.IssueId, ct);
+        if (issue == null) return Result<IssueDto>.Failure(IssueErrorCodes.NotFound);
+
+        if (issue.Labels.Remove(request.Label))
+        {
+            await _repository.UpdateAsync(issue, ct);
+
+            await _publisher.Publish(
+                new IssueUpdatedEvent { IssueId = issue.Id },
+                ct
+            );
+        }
+
+        return Result<IssueDto>.Success(_mapper.ToDto(issue));
+    }
+}
+```
+
+#### Label Suggestions & Autocomplete
+
+The `ILabelService` aggregates distinct labels from all existing issues:
+
+```csharp
+public sealed class LabelService : ILabelService
+{
+    private readonly IRepository<Issue> _repository;
+
+    public async Task<IReadOnlyList<string>> GetLabelSuggestionsAsync(
+        string prefix,
+        CancellationToken ct = default)
+    {
+        var allIssues = await _repository.GetAllAsync(ct);
+        var suggestions = allIssues
+            .SelectMany(i => i.Labels)
+            .Distinct()
+            .Where(label => label.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(label => label)
+            .ToList();
+
+        return suggestions;
+    }
+}
+```
+
+The API endpoint is simple and fast:
+
+```csharp
+var labelGroup = app.MapGroup("/api/labels")
+    .WithName("Labels")
+    .RequireAuthorization("AdminPolicy");
+
+labelGroup.MapGet("/suggestions", async (
+    string prefix,
+    ILabelService labelService,
+    CancellationToken ct) =>
+{
+    var suggestions = await labelService.GetLabelSuggestionsAsync(prefix, ct);
+    return Results.Ok(suggestions);
+})
+.WithName("GetLabelSuggestions")
+.WithOpenApi();
+```
+
+#### LabelInput.razor Component
+
+The `LabelInput` component provides a polished tag input experience:
+
+```razor
+@component
+@implements IAsyncDisposable
+@typeparam TItem where TItem : IEquatable<TItem>
+
+<div class="label-input">
+    <div class="tag-list">
+        @foreach (var label in Labels)
+        {
+            <span class="tag">
+                @label
+                <button type="button" @onclick="() => RemoveLabel(label)">×</button>
+            </span>
+        }
+        <input
+            type="text"
+            placeholder="Add label..."
+            @bind="inputValue"
+            @oninput="OnInputAsync"
+            @onkeydown="OnKeyDown"
+            class="input"
+        />
+    </div>
+    
+    @if (showSuggestions && suggestions.Any())
+    {
+        <div class="suggestions">
+            @foreach (var suggestion in suggestions)
+            {
+                <div class="suggestion" @onclick="() => SelectLabel(suggestion)">
+                    @suggestion
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public List<string> Labels { get; set; } = [];
+
+    [Parameter]
+    public EventCallback<List<string>> LabelsChanged { get; set; }
+
+    private string inputValue = "";
+    private List<string> suggestions = [];
+    private bool showSuggestions = false;
+
+    private async Task OnInputAsync(ChangeEventArgs e)
+    {
+        inputValue = e.Value?.ToString() ?? "";
+        // Debounce autocomplete
+        await Task.Delay(300);
+        suggestions = await LabelService.GetLabelSuggestionsAsync(inputValue);
+        showSuggestions = suggestions.Any();
+    }
+
+    private void OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" || e.Key == ",")
+        {
+            SelectLabel(inputValue.Trim(',').TrimEnd());
+        }
+        else if (e.Key == "Backspace" && string.IsNullOrEmpty(inputValue) && Labels.Any())
+        {
+            RemoveLabel(Labels[^1]);
+        }
+    }
+
+    private void SelectLabel(string label)
+    {
+        if (string.IsNullOrWhiteSpace(label)) return;
+        if (!Labels.Contains(label))
+            Labels.Add(label);
+        inputValue = "";
+        showSuggestions = false;
+    }
+
+    private void RemoveLabel(string label)
+    {
+        Labels.Remove(label);
+        StateHasChanged();
+    }
+}
+```
+
+#### Filter Issues by Label
+
+The Issues page supports URL-based filtering:
+
+```razor
+@page "/issues"
+@inject NavigationManager NavigationManager
+@inject IIssueService IssueService
+
+<div class="filter-chips">
+    @foreach (var label in SelectedLabels)
+    {
+        <button class="chip" @onclick="() => ToggleLabel(label)">
+            @label ✕
+        </button>
+    }
+</div>
+
+<IssueListTable Issues="@FilteredIssues" />
+
+@code {
+    private List<string> SelectedLabels = [];
+    private List<IssueDto> AllIssues = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        AllIssues = await IssueService.GetIssuesAsync();
+        var query = new Uri(NavigationManager.Uri).Query;
+        var labels = HttpUtility.ParseQueryString(query)["label"];
+        if (!string.IsNullOrEmpty(labels))
+            SelectedLabels = labels.Split(',').ToList();
+    }
+
+    private List<IssueDto> FilteredIssues =>
+        SelectedLabels.Any()
+            ? AllIssues.Where(i => SelectedLabels.All(l => i.Labels.Contains(l))).ToList()
+            : AllIssues;
+
+    private void ToggleLabel(string label)
+    {
+        if (SelectedLabels.Contains(label))
+            SelectedLabels.Remove(label);
+        else
+            SelectedLabels.Add(label);
+
+        var labelParam = string.Join(",", SelectedLabels);
+        NavigationManager.NavigateTo(
+            $"issues?label={Uri.EscapeDataString(labelParam)}"
+        );
+    }
+}
+```
+
+#### Test Coverage
+
+- **LabelInputTests.cs** (10 tests): Render with initial labels, add label via Enter, remove label via backspace, autocomplete suggestions, duplicate label handling.
+- **LabelFilterChipTests.cs** (3 tests): Render chips for selected labels, toggle label on click, update URL query parameters.
+- **AddLabelCommand & RemoveLabelCommand Tests**: Idempotent semantics, event publishing, repository persistence.
+- **LabelService Tests**: Distinct label aggregation, prefix-based filtering, case-insensitive search.
+
+---
+
+## How to Upgrade
+
+1. **From v0.5.0 → v0.6.0**: No breaking changes. Git pull, `dotnet restore`, `dotnet build`.
+2. **New Label Features**: Create Issue and Edit Issue forms now include the `LabelInput` component. Existing issues have empty label lists.
+3. **Filter by Label**: Use the `?label=bug,v2` query param on `/issues` to filter by multiple labels.
+4. **Label Suggestions**: Type in the `LabelInput` to see autocomplete suggestions from existing issue labels.
+
+---
+
+## Performance & Scale
+
+- **Simple Label Storage**: Labels are stored as `List<string>` on the Issue, keeping queries fast and the domain model minimal.
+- **Efficient Aggregation**: `LabelService` queries all issues once and aggregates distinct labels in memory—sufficient for current scale.
+- **Autocomplete Debounce**: 300ms debounce prevents excessive API calls during typing.
+- **URL-Based Filtering**: Label filters are stored in the URL query string, enabling bookmarking and sharing.
+
+---
+
+## Test Coverage Summary
+
+**Sprint 6 Total: 1,167 tests** (up from 1,050 before Sprint 6)
+
+- **716 bUnit tests**: Component rendering, user interactions, event handling
+- **404 Domain/CQRS tests**: Command handlers, query handlers, validator logic
+- **60 Architecture tests**: Naming conventions, layer boundaries, handler placement
+
+---
+
+## What's Next
+
+With v0.6.0, the core issue management features are mature. Upcoming work includes:
+
+- **Bulk Label Operations**: Add/remove labels to multiple issues at once
+- **Label Management UI**: Create, rename, delete label presets
+- **Label Analytics**: Visualize issue distribution by label
+- **Webhooks & Integrations**: Trigger webhooks on label changes
+
+---
+
+**Release v0.6.0:** [Full Changelog](https://github.com/mpaulosky/IssueTrackerApp/compare/v0.5.0...v0.6.0)
+
+**Key Issues Closed:** [#148](https://github.com/mpaulosky/IssueTrackerApp/issues/148), [#149](https://github.com/mpaulosky/IssueTrackerApp/issues/149), [#150](https://github.com/mpaulosky/IssueTrackerApp/issues/150), [#151](https://github.com/mpaulosky/IssueTrackerApp/issues/151), [#152](https://github.com/mpaulosky/IssueTrackerApp/issues/152), [#153](https://github.com/mpaulosky/IssueTrackerApp/issues/153), [#154](https://github.com/mpaulosky/IssueTrackerApp/issues/154), [#155](https://github.com/mpaulosky/IssueTrackerApp/issues/155), [#156](https://github.com/mpaulosky/IssueTrackerApp/issues/156)

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -8,6 +8,8 @@ Here we document new features, architectural decisions, testing milestones, and 
 
 | Date | Title | Tags |
 |------|-------|------|
+| 2026-04-02 | [Release v0.6.0 — Labels Feature](2026-04-02-release-v0-6-0.md) | release, v0.6.0, labels, cqrs, blazor, bunit |
+| 2026-04-02 | [Release v0.5.0 — Admin User Management](2026-04-02-release-v0-5-0.md) | release, v0.5.0, admin, auth0, blazor |
 | 2026-04-01 | [Release v0.4.0 — Voting & Prioritization](2026-04-01-release-v0-4-0.md) | release, v0.4.0, voting, cqrs, signalr |
 | 2026-04-01 | [Release v0.3.0 — Polish Sprint](2026-04-01-release-v0-3-0.md) | release, v0.3.0, dashboard, redis, assignee |
 | 2026-03-30 | [Release v0.2.0 — Features, Fixes & Developer Tooling](2026-03-30-release-v0-2-0.md) | release, v0.2.0, features, testing, devops |

--- a/docs/index.html
+++ b/docs/index.html
@@ -463,7 +463,17 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
             </thead>
             <tbody>
                 <tr>
-                    <td><a href="https://github.com/mpaulosky/IssueTrackerApp/releases/tag/v0.4.0"><strong>v0.4.0</strong></a> <span style="background:#dafbe1;color:#1a7f37;font-size:0.75em;padding:2px 6px;border-radius:10px;font-weight:600;">Latest</span></td>
+                    <td><a href="https://github.com/mpaulosky/IssueTrackerApp/releases/tag/v0.6.0"><strong>v0.6.0</strong></a> <span style="background:#dafbe1;color:#1a7f37;font-size:0.75em;padding:2px 6px;border-radius:10px;font-weight:600;">Latest</span></td>
+                    <td>2026-04-02</td>
+                    <td>Labels Feature — multi-value tag input, filter by label, AddLabelCommand/RemoveLabelCommand CQRS, 1,167 tests</td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/mpaulosky/IssueTrackerApp/releases/tag/v0.5.0">v0.5.0</a></td>
+                    <td>2026-04-02</td>
+                    <td>Admin User Management — Auth0 Management API, /admin/users, UserListTable, RoleBadge, EditUserRolesModal, UserAuditLogPanel</td>
+                </tr>
+                <tr>
+                    <td><a href="https://github.com/mpaulosky/IssueTrackerApp/releases/tag/v0.4.0">v0.4.0</a></td>
                     <td>2026-04-01</td>
                     <td>Voting &amp; Prioritization — upvote/unvote issues, vote badge, Top Voted sort, SignalR broadcast</td>
                 </tr>
@@ -495,6 +505,16 @@ dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
                 </tr>
             </thead>
             <tbody>
+                <tr>
+                    <td>2026-04-02</td>
+                    <td><a href="blog/2026-04-02-release-v0-6-0.md">Release v0.6.0 — Labels Feature</a></td>
+                    <td>release, v0.6.0, labels, cqrs, blazor, bunit</td>
+                </tr>
+                <tr>
+                    <td>2026-04-02</td>
+                    <td><a href="blog/2026-04-02-release-v0-5-0.md">Release v0.5.0 — Admin User Management</a></td>
+                    <td>release, v0.5.0, admin, auth0, blazor</td>
+                </tr>
                 <tr>
                     <td>2026-04-01</td>
                     <td><a href="blog/2026-04-01-release-v0-4-0.md">Release v0.4.0 — Voting &amp; Prioritization</a></td>


### PR DESCRIPTION
## Summary

This PR adds two new release blog posts:

- **Release v0.5.0 — Admin User Management** (2026-04-02)
  - Auth0 Management API integration
  - /admin/users page with UserListTable, RoleBadge, EditUserRolesModal, UserAuditLogPanel
  - Full CQRS handlers and comprehensive test coverage

- **Release v0.6.0 — Labels Feature** (2026-04-02)
  - Multi-value tag input (LabelInput.razor) with debounced autocomplete
  - AddLabelCommand/RemoveLabelCommand CQRS handlers
  - Filter issues by label with URL-based state management
  - 1,167 total tests (up from 1,050)

## Changes

- Add `docs/blog/2026-04-02-release-v0-5-0.md`
- Add `docs/blog/2026-04-02-release-v0-6-0.md`
- Update `docs/blog/index.md` with new entries
- Update `docs/index.html` RELEASES and BLOG tables

Both blog posts follow the established style from v0.4.0 release post, with architecture deep dives, code examples, and test coverage summaries.