### PR TITLE
docs(squad): add worktree trigger phrases to ceremonies + merge decision

### DIFF
--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -436,9 +436,12 @@ echo "✅ Orphan branch cleanup complete."
 
 ### Git Worktree Setup Ceremony
 
-- **Trigger:** manual — when starting a new sprint or when multiple squad branches are active simultaneously
-- **When:** before beginning sprint work
-- **Facilitator:** Boromir / Aragorn
+- **Trigger:** any of the following:
+  - User says "use worktrees", "use a worktree", "isolate in a worktree", or "set up a sprint worktree"
+  - ≥2 squad branches are active simultaneously
+  - A new sprint begins with parallel workstreams planned
+- **When:** before beginning sprint work, or at plan creation time when isolation is requested
+- **Facilitator:** Boromir / Aragorn / Copilot (Coding Agent)
 - **Purpose:** Isolate squad branch work, scribe/planning commits, and main branch to prevent `.squad/` files bleeding into feature branches
 
 #### Worktree Layout

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2514,3 +2514,39 @@ _active ? "btn btn-primary" : "btn btn-secondary"
 
 **Scribe Note:** Merged from decision inbox file `legolas-btn-consolidation.md`
 
+
+---
+
+### Git Workflow
+
+#### Git Worktrees as Standard Isolation Strategy (2026-04-03)
+
+**By:** Matthew Paulosky (via Copilot)
+**What:** Adopt git worktrees as the standard isolation strategy for squad planning, scribe, and sprint branch work.
+**Why:** Single-worktree workflow caused recurring `.squad/` files bleeding into `feature/*` branches, context-switching overhead, and inability to run parallel sprint branches without interference.
+
+**Layout:**
+```
+~/Repos/
+├── IssueTrackerApp/            ← main worktree  (stays on main)
+├── IssueTrackerApp-scribe/     ← scribe/planning worktree (.squad/ commits only)
+└── IssueTrackerApp-sprint/     ← active sprint worktree (squad/{issue}-{slug})
+```
+
+**Trigger phrases:** "use worktrees", "use a worktree", "isolate in a worktree", "set up a sprint worktree", or automatically when ≥2 squad branches are active.
+
+**Rules:**
+- Main worktree stays on `main` — never used for active squad branch work
+- Scribe worktree: only `.squad/` commits — no source code changes
+- Sprint worktrees: one per active squad branch
+- No simultaneous `dotnet build` — `bin/`/`obj/` are shared
+- Pre-push hook enforced in every worktree
+
+**Setup:**
+```bash
+git worktree add ../IssueTrackerApp-scribe squad/scribe-log-updates
+git worktree add ../IssueTrackerApp-sprint -b squad/{issue-number}-{slug}
+git worktree remove ../IssueTrackerApp-sprint  # after merge
+```
+
+**Scribe Note:** Merged from decision inbox file `copilot-git-worktrees.md`


### PR DESCRIPTION
## Summary

Adds explicit trigger phrases to the Git Worktree Setup Ceremony so squad members and agents know exactly when worktrees should be set up.

Also merges the `copilot-git-worktrees.md` inbox decision into the shared `.squad/decisions.md` under a new Git Workflow section.

## Changes
- `.squad/ceremonies.md` — explicit trigger phrases added to Git Worktree Setup Ceremony
- `.squad/decisions.md` — new Git Workflow section with worktrees decision

Closes no issue (infra/docs housekeeping)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>