### PR TITLE
Add pre-push and merge playbooks, fix process documentation

### DIFF
--- a/.copilot/skills/ci-validation-gates/SKILL.md
+++ b/.copilot/skills/ci-validation-gates/SKILL.md
@@ -6,6 +6,8 @@ confidence: "high"
 source: "extracted from Drucker and Trejo charters — earned knowledge from v0.8.22 release incident"
 ---
 
+> ⚠️ **Squad CLI Only** — This skill documents npm/CI patterns from the Squad CLI project (v0.8.22 incident). It is NOT applicable to IssueTrackerApp (.NET/Blazor). For IssueTrackerApp CI gates, see `.github/hooks/pre-push` and `.squad/playbooks/pre-push-process.md`.
+
 ## Context
 
 CI workflows must be defensive. These patterns were learned from the v0.8.22 release disaster where invalid semver, wrong token types, missing retry logic, and draft releases caused a multi-hour outage. Both Drucker (CI/CD) and Trejo (Release Manager) carried this knowledge in their charters — now centralized here.

--- a/.copilot/skills/pre-push-test-gate/SKILL.md
+++ b/.copilot/skills/pre-push-test-gate/SKILL.md
@@ -1,90 +1,85 @@
 ---
 name: pre-push-test-gate
 confidence: high
+source: .github/hooks/pre-push
 description: >
-  Enforces build cleanliness and test passage before any git push.
-  Delegates to the build-repair prompt (.github/prompts/build-repair.prompt.md)
-  as the authoritative gate. Established after the Shared project test batch
-  (04714a4) shipped two broken tests directly to main.
+  Knowledge skill documenting the 5-gate pre-push hook that enforces build
+  cleanliness and full test passage before any git push. The hook is installed
+  at .git/hooks/pre-push and mirrors CI gates locally.
 ---
 
 ## Pre-Push Test Gate
 
-### Why This Exists
+### Overview
 
-On 2026-02-25, two unit tests were pushed directly to `main` without local verification.
-Both tests had wrong expectations and failed in CI. This skill enforces the gate that
-prevents that from recurring.
+The pre-push hook (`.github/hooks/pre-push`) enforces **5 gates** that mirror CI. It runs automatically on every `git push` and blocks the push if any gate fails.
 
-### The Gate
+> 📋 **For the step-by-step execution playbook, see:** `.squad/playbooks/pre-push-process.md`
 
-Before any `git push`, an agent MUST run the **Build Repair Skill**:
+### The 5 Gates
 
-> **`.github/prompts/build-repair.prompt.md`**
+| Gate | Name | What It Does | Blocks If |
+|------|------|-------------|-----------|
+| **0** | Branch protection | Checks current branch | Push is to `main` |
+| **1** | Untracked source files | Scans for untracked `.razor`/`.cs` files | Untracked source files found (prompts y/N) |
+| **2** | Release build | `dotnet build IssueTrackerApp.slnx --configuration Release` | Build fails (3 retries) |
+| **3** | Unit/Arch/bUnit tests | Runs 6 test projects in Release mode | Any test project fails (3 retries) |
+| **4** | Integration tests | Runs 4 integration test projects (Docker required) | Any test project fails (3 retries) |
 
-That prompt already defines the full gate:
-1. Restore dependencies (`dotnet restore`)
-2. Build the solution (`dotnet build --no-restore`) — zero errors, zero warnings
-3. Fix any build errors before continuing
-4. Run unit tests — all must pass
-5. Fix test failures before continuing
+### Gate 3 — Unit Test Projects (6 total)
 
-Only push when the build-repair prompt reports **"Build succeeded"** with **zero warnings**
-and **all tests pass**.
+```
+tests/Architecture.Tests/Architecture.Tests.csproj
+tests/Domain.Tests/Domain.Tests.csproj
+tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj
+tests/Persistence.MongoDb.Tests/Persistence.MongoDb.Tests.csproj
+tests/Web.Tests/Web.Tests.csproj
+tests/Persistence.AzureStorage.Tests/Persistence.AzureStorage.Tests.csproj
+```
 
-### Agent Checklist
+### Gate 4 — Integration Test Projects (4 total, Docker required)
 
-Before any `git push`, an agent MUST:
+```
+tests/Persistence.MongoDb.Tests.Integration/Persistence.MongoDb.Tests.Integration.csproj
+tests/Web.Tests.Integration/Web.Tests.Integration.csproj
+tests/Persistence.AzureStorage.Tests.Integration/Persistence.AzureStorage.Tests.Integration.csproj
+tests/AppHost.Tests/AppHost.Tests.csproj
+```
 
-- [ ] Open `.github/prompts/build-repair.prompt.md` and execute it fully
-- [ ] Confirm final output: `Build succeeded. 0 Warning(s). 0 Error(s).`
-- [ ] Confirm final test output: `Passed! Failed: 0`
-- [ ] Only then execute `git push`
+These use Testcontainers (mongo:7.0, Azurite) and Aspire DCP. Docker daemon MUST be running.
 
-Do NOT push if either check reports failures. Fix first.
+### Retry Behavior
 
-### Hook (Local Enforcement)
+Gates 2, 3, and 4 allow **3 attempts**. Between attempts the hook pauses and prompts:
+> "Fix the errors and press Enter to retry, or Ctrl+C to abort"
 
-The `.git/hooks/pre-push` hook runs unit tests as a local tripwire.
-Install once per clone — **Shell (Linux/macOS/Git Bash)**:
+### Hook Installation
+
+The hook source is committed at `.github/hooks/pre-push`. Install once per clone:
 
 ```bash
-cat > .git/hooks/pre-push << 'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-echo "🔎 pre-push: running build-repair gate (Domain.Tests + Web.Tests)…"
-if dotnet test tests/Domain.Tests tests/Web.Tests --configuration Release --verbosity quiet 2>&1; then
-  echo "✅ Gate passed — push allowed."
-else
-  echo "❌ Gate FAILED. Run .github/prompts/build-repair.prompt.md and fix before pushing."
-  exit 1
-fi
-EOF
+cp .github/hooks/pre-push .git/hooks/pre-push
 chmod +x .git/hooks/pre-push
 ```
 
-**PowerShell (Windows):**
-```powershell
-@'
-#!/usr/bin/env bash
-set -euo pipefail
-echo "🔎 pre-push: running build-repair gate (Domain.Tests + Web.Tests)…"
-if dotnet test tests/Domain.Tests tests/Web.Tests --configuration Release --verbosity quiet 2>&1; then
-  echo "✅ Gate passed — push allowed."
-else
-  echo "❌ Gate FAILED. Run .github/prompts/build-repair.prompt.md and fix before pushing."
-  exit 1
-fi
-'@ | Set-Content -NoNewline .git/hooks/pre-push
-```
+> ⚠️ Do NOT create inline hook scripts. Always copy from `.github/hooks/pre-push` to get the full 5-gate version.
 
-> The hook is not committed — install on every fresh clone. The build-repair prompt
-> is the authoritative process; the hook is a fast local tripwire.
-
-### Failure Taxonomy (known patterns)
+### Failure Taxonomy (Known Patterns)
 
 | Symptom | Root Cause | Fix |
 |---------|-----------|-----|
-| `DateTime` equality failure in `*.Empty` tests | `Empty` property calls `DateTime.UtcNow` each time — two calls produce different values | Assert individual fields, not whole-record equality |
-| Unexpected trailing `_` in slug tests | `GenerateSlug` appends `_` when string ends with punctuation AND has internal punctuation | Verify actual output against implementation before asserting |
-| Record equality fails on nested DTO | Nested DTO `Empty` also uses `UtcNow` — same root cause | Flatten assertions to field-level |
+| Warning treated as error (Gate 2) | `TreatWarningsAsErrors=true` in Directory.Build.props | Fix the warning — do not suppress |
+| Architecture test failure (Gate 3) | Naming convention violation | Commands → `Command`, queries → `Query`, handlers → `Handler` (must be `sealed`), validators → `Validator` |
+| bUnit test failure (Gate 3) | API change in bUnit 2.x | Use `Render<T>()` not `RenderComponent<T>()` |
+| `DateTime` equality failure (Gate 3) | `Empty` property calls `DateTime.UtcNow` each time | Assert individual fields, not whole-record equality |
+| Docker not running (Gate 4) | Testcontainers can't start | `sudo systemctl start docker` or start Docker Desktop |
+| Container timeout (Gate 4) | Slow image pull or low resources | Pre-pull `mongo:7.0`; increase Docker memory |
+| Untracked `.razor`/`.cs` (Gate 1) | New files not staged | `git add <files>` before pushing |
+
+### Related Documents
+
+- **Hook source:** `.github/hooks/pre-push`
+- **Execution playbook:** `.squad/playbooks/pre-push-process.md`
+- **Build repair prompt:** `.github/prompts/build-repair.prompt.md`
+- **Contributing guide:** `CONTRIBUTING.md` (Pre-Push Gates section)
+- **Ceremonies:** `.squad/ceremonies.md` (Build Repair Check)

--- a/.copilot/skills/release-process/SKILL.md
+++ b/.copilot/skills/release-process/SKILL.md
@@ -6,6 +6,8 @@ confidence: "high"
 source: "team-decision"
 ---
 
+> ⚠️ **Squad CLI Only** — This skill documents the npm release runbook for Squad CLI (`@bradygaster/squad-sdk` and `@bradygaster/squad-cli`). It is NOT applicable to IssueTrackerApp (.NET/Blazor). For IssueTrackerApp releases, see `.squad/playbooks/release-issuetracker.md`.
+
 ## Context
 
 This is the **definitive release runbook** for Squad. Born from the v0.8.22 release disaster (4-part semver mangled by npm, draft release never triggered publish, wrong NPM_TOKEN type, 6+ hours of broken `latest` dist-tag).

--- a/.copilot/skills/squad-conventions/SKILL.md
+++ b/.copilot/skills/squad-conventions/SKILL.md
@@ -6,6 +6,8 @@ confidence: "high"
 source: "manual"
 ---
 
+> ⚠️ **Squad CLI Only** — This skill documents conventions for the [Squad CLI](https://github.com/bradygaster/squad) Node.js package. It is NOT applicable to IssueTrackerApp (.NET/Blazor). Agents working on IssueTrackerApp should ignore this skill.
+
 ## Context
 These conventions apply to all work on the Squad CLI tool (`create-squad`). Squad is a zero-dependency Node.js package that adds AI agent teams to any project. Understanding these patterns is essential before modifying any Squad source code.
 

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -17,12 +17,14 @@
 1. Derive the milestone name from the plan title or epic (e.g., "Sprint 1 — {feature/epic name}")
 2. Set a due date if the user specified one; otherwise leave blank
 3. Create via GitHub API (note: `gh` does not have a `milestone create` subcommand natively):
+
    ```bash
    gh api repos/{owner}/{repo}/milestones --method POST \
      --field title="{milestone-name}" \
      --field description="{plan summary}" \
      [--field due_on="{ISO8601}"]
    ```
+
 4. Confirm creation and record the milestone number
 
 #### Phase 2: Sprint Definition
@@ -35,24 +37,29 @@
 #### Phase 3: Issue Creation + Sprint Assignment
 
 1. For each todo in the plan, create a GitHub issue:
+
    ```bash
    gh issue create --title "{todo title}" \
      --body "{todo description}" \
      --label "squad" \
      --milestone "{milestone-name}"
    ```
+
 2. Assign sprint grouping via a label: `sprint-{N}` (create the label if it doesn't exist):
+
    ```bash
    gh label create "sprint-{N}" --color "{color}" \
      --description "Sprint {N}" 2>/dev/null || true
    gh issue edit {number} --add-label "sprint-{N}"
    ```
+
 3. Add appropriate `squad:{member}` routing labels based on the todo domain
 
 #### Phase 4: Board Summary
 
 Present a summary table:
-```
+
+```md
 📅 Milestone: {name} (#{number})
 ├── 🏃 Sprint 1 — {theme}: {N} issues
 │   ├── #{issue} {title} [squad:sam]
@@ -76,6 +83,7 @@ Present a summary table:
 - **Facilitator:** Aragorn
 - **Participants:** Aragorn (runs build-repair prompt)
 - **Purpose:** Ensure zero errors, zero warnings, all tests pass before pushing
+- **Playbook:** `.squad/playbooks/pre-push-process.md` (full 5-gate walkthrough)
 - **Critical rules (learned from PR #86 incident):**
   1. **Always use `--configuration Release`** — CI uses Release; Debug builds hide missing files. Never accept a Debug-only passing build.
   2. **Stage ALL untracked `.razor`/`.cs` files before committing** — run `git status --short` and treat any `??` source file as a blocker. Files present on disk but untracked are invisible to CI.
@@ -96,17 +104,18 @@ Present a summary table:
 - **When:** after ALL CI checks pass; do NOT trigger while checks are pending or failing
 - **Facilitator:** Aragorn
 - **Participants:** Aragorn (always) + domain specialists determined by files changed:
+- **Playbook:** `.squad/playbooks/pr-merge-process.md` (full merge lifecycle)
 
-| Files changed | Required reviewer |
-|---------------|-------------------|
-| Any file | **Aragorn** (lead — always required) |
-| `.github/workflows/`, `AppHost.csproj`, `Directory.Packages.props` | **Boromir** |
-| `Auth/`, `appsettings*.json` auth sections, `Program.cs` auth sections, `UserManagementService.cs`, `Auth0ClaimsTransformation.cs` | **Gandalf** |
-| `tests/Domain.Tests/`, `tests/Web.Tests.Bunit/`, `tests/Persistence.*/` | **Gimli** |
-| `tests/AppHost.Tests/` (Playwright / Aspire E2E) | **Pippin** |
-| `src/Domain/`, `src/Persistence.*/`, `src/Web/Endpoints/`, `src/Web/Features/` | **Sam** |
-| `src/Web/Components/`, `*.razor`, `*.razor.cs`, `*.razor.css`, `wwwroot/` | **Legolas** |
-| `docs/`, `README.md`, XML doc changes | **Frodo** |
+| Files changed                                                                                                                      | Required reviewer                    |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Any file                                                                                                                           | **Aragorn** (lead — always required) |
+| `.github/workflows/`, `AppHost.csproj`, `Directory.Packages.props`                                                                 | **Boromir**                          |
+| `Auth/`, `appsettings*.json` auth sections, `Program.cs` auth sections, `UserManagementService.cs`, `Auth0ClaimsTransformation.cs` | **Gandalf**                          |
+| `tests/Domain.Tests/`, `tests/Web.Tests.Bunit/`, `tests/Persistence.*/`                                                            | **Gimli**                            |
+| `tests/AppHost.Tests/` (Playwright / Aspire E2E)                                                                                   | **Pippin**                           |
+| `src/Domain/`, `src/Persistence.*/`, `src/Web/Endpoints/`, `src/Web/Features/`                                                     | **Sam**                              |
+| `src/Web/Components/`, `*.razor`, `*.razor.cs`, `*.razor.css`, `wwwroot/`                                                          | **Legolas**                          |
+| `docs/`, `README.md`, XML doc changes                                                                                              | **Frodo**                            |
 
 - **Purpose:** Quality and security gate before merge
 
@@ -123,9 +132,11 @@ Ralph MUST verify ALL of the following before the review cycle begins. Any faili
 
 1. Determine required reviewers from the files-changed table above
 2. **Read GitHub Copilot's automated review comments first:**
+
    ```bash
    gh pr view {N} --json reviews -q '.reviews[] | select(.author.login == "copilot-pull-request-reviewer") | .body'
    ```
+
    Aragorn must address any Copilot-flagged bugs, security issues, or logic errors
    before posting his own verdict. Copilot style suggestions are discretionary.
 3. Spawn Aragorn + all required domain reviewers **in parallel**
@@ -175,7 +186,7 @@ The PR author (original agent who pushed the branch) is **locked out** of fixing
 
 #### Comment template (posted by Aragorn on PR when routing fixes)
 
-```
+```md
 🔄 **CHANGES_REQUESTED — Routing fix cycle**
 
 Reviewer: @{reviewer} requested changes.
@@ -197,19 +208,22 @@ Fix agent: please push corrections to `{branch}` and comment when ready for re-r
 - **Facilitator:** Aragorn (decides resolver and strategy)
 - **Purpose:** Unblock PRs with merge conflicts without violating review integrity
 
-#### Protocol
+#### Protocol 1
 
 1. **Ralph detects** conflict → posts comment on PR:
-   ```
+
+   ```md
    ⚠️ **Merge conflict detected** on `{branch}`. This PR cannot merge until conflicts are resolved.
    Pinging Aragorn to route resolution.
    ```
+
 2. **Aragorn determines** which files conflict (`gh pr view {N} --json files`) and routes to:
    - Backend files (`src/Domain/`, `src/Persistence.*/`) → **Sam**
    - Frontend files (`src/Web/Components/`, `*.razor`) → **Legolas**
    - CI/config files (`.github/`, `*.csproj`, `*.props`) → **Boromir**
    - Mixed or architectural conflicts → **Aragorn** resolves directly
 3. **Resolver** checks out the branch and merges:
+
    ```bash
    git checkout {branch}
    git fetch origin
@@ -219,6 +233,7 @@ Fix agent: please push corrections to `{branch}` and comment when ready for re-r
    git commit -m "chore: resolve merge conflicts with main\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
    git push
    ```
+
 4. **CI must re-pass** after the merge commit
 5. **Existing reviews are invalidated** — all reviewers must re-approve after a merge commit
 6. Resume PR Review Gate from the beginning
@@ -235,15 +250,15 @@ Fix agent: please push corrections to `{branch}` and comment when ready for re-r
 
 #### When to Run
 
-| Trigger | Who |
-|---------|-----|
-| After `gh pr merge` succeeds | Ralph (automatic) |
-| Manual request ("clean orphan branches") | Ralph (on demand) |
-| Before sprint planning | Aragorn (includes in pre-sprint checklist) |
+| Trigger                                  | Who                                        |
+| ---------------------------------------- | ------------------------------------------ |
+| After `gh pr merge` succeeds             | Ralph (automatic)                          |
+| Manual request ("clean orphan branches") | Ralph (on demand)                          |
+| Before sprint planning                   | Aragorn (includes in pre-sprint checklist) |
 
-#### Protocol
+#### Protocol 2
 
-**Step 1 — Sync and prune remote tracking refs**
+#### **Step 1 — Sync and prune remote tracking refs**
 
 ```bash
 git checkout main
@@ -253,7 +268,7 @@ git fetch --prune
 
 `--prune` removes local tracking refs (`origin/squad/*`) for branches already deleted on origin.
 
-**Step 2 — Delete merged remote branches (origin)**
+#### **Step 2 — Delete merged remote branches (origin)**
 
 Catches any `squad/*` branches not removed by `--delete-branch` at merge time:
 
@@ -264,7 +279,7 @@ git branch -r --merged origin/main \
   | xargs -r -I{} git push origin --delete {}
 ```
 
-**Step 3 — Delete merged local branches**
+#### **Step 3 — Delete merged local branches**
 
 ```bash
 git branch --merged main \
@@ -272,7 +287,7 @@ git branch --merged main \
   | xargs -r git branch -d
 ```
 
-**Step 4 — Delete local branches whose remote is gone**
+#### **Step 4 — Delete local branches whose remote is gone**
 
 Handles branches where the remote was already deleted but the local ref was not cleaned up:
 
@@ -286,7 +301,7 @@ git branch -vv \
 
 > ⚠️ Step 4 uses `-D` (force delete) because these branches are already gone from origin. Only applies to `squad/` branches to avoid accidentally removing other local work.
 
-**Step 5 — Report**
+#### **Step 5 — Report**
 
 Print surviving branches for visibility:
 
@@ -317,6 +332,7 @@ echo "✅ Orphan branch cleanup complete."
 - **Facilitator:** Agent or human working the task
 - **Participants:** Task owner, reviewers (for PR phase)
 - **Purpose:** Ensure consistent task execution with proper branch isolation and verification
+- **Playbooks:** `.squad/playbooks/pre-push-process.md` (Phase 3: push), `.squad/playbooks/pr-merge-process.md` (Phase 4: review/merge)
 - **Enforcement:** The pre-push hook (Gate 0) blocks direct pushes to `main` — you must use a `squad/{issue}-{slug}` feature branch
 
 #### Phases
@@ -384,11 +400,13 @@ echo "✅ Orphan branch cleanup complete."
    - If rejected: identify fixes → route to a DIFFERENT agent (not the PR author, lockout enforced) → push fixes → wait for CI → repeat from step 1
 
 4. **Merge (squash):**
+
    ```bash
    gh pr merge {N} --squash --delete-branch
    ```
 
 5. **Update local main:**
+
    ```bash
    git checkout main
    git pull origin main
@@ -416,7 +434,7 @@ echo "✅ Orphan branch cleanup complete."
 - **Participants:** Aragorn, Legolas, Sam, Gimli, Boromir, Frodo, Bilbo
 - **Purpose:** Review shipped deliverables, confirm all sprint issues closed and PRs merged, prepare for release
 
-#### Protocol
+#### Protocol 3
 
 1. Aragorn confirms all sprint issues are closed: `gh issue list --state open --label "sprint-{N}"`
 2. Aragorn summarizes what shipped: features, fixes, test counts added
@@ -432,7 +450,7 @@ echo "✅ Orphan branch cleanup complete."
 - **Participants:** Aragorn, Sam, Legolas, Gimli
 - **Purpose:** Ensure open issues are properly labeled, scoped, and ready before sprint planning
 
-#### Protocol
+#### Protocol 4
 
 1. List open issues: `gh issue list --label "squad" --state open --json number,title,labels`
 2. For each issue without `squad:{member}` sub-label: triage and assign appropriate sub-label
@@ -452,7 +470,7 @@ echo "✅ Orphan branch cleanup complete."
 
 #### Worktree Layout
 
-```
+```md
 ~/Repos/
 ├── IssueTrackerApp/            ← main worktree  (main branch, read-only reference)
 ├── IssueTrackerApp-scribe/     ← scribe/planning worktree  (squad/scribe-* branches)
@@ -478,14 +496,14 @@ git branch -d squad/{issue-number}-{slug}
 
 #### Rules
 
-| Rule | Detail |
-|------|--------|
-| **Main worktree** | Stays on `main`. Never used for active squad branch work. |
-| **Scribe worktree** | Only `.squad/` commits live here. No source code changes. |
-| **Sprint worktrees** | One per active squad branch. |
-| **No simultaneous builds** | `bin/` and `obj/` are shared; do not run `dotnet build` in two worktrees simultaneously. |
-| **Pre-push hook** | Runs in every worktree — all gates still enforced. |
-| **Branching guard** | `.squad/` files must never appear in sprint/feature worktree commits — the scribe worktree makes this physically impossible. |
+| Rule                       | Detail                                                                                                                       |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Main worktree**          | Stays on `main`. Never used for active squad branch work.                                                                    |
+| **Scribe worktree**        | Only `.squad/` commits live here. No source code changes.                                                                    |
+| **Sprint worktrees**       | One per active squad branch.                                                                                                 |
+| **No simultaneous builds** | `bin/` and `obj/` are shared; do not run `dotnet build` in two worktrees simultaneously.                                     |
+| **Pre-push hook**          | Runs in every worktree — all gates still enforced.                                                                           |
+| **Branching guard**        | `.squad/` files must never appear in sprint/feature worktree commits — the scribe worktree makes this physically impossible. |
 
 ---
 
@@ -507,7 +525,7 @@ git branch -d squad/{issue-number}-{slug}
 
 #### Flow
 
-```
+```md
 Milestone closed
       ↓
 [milestone-blog.yml] creates Ralph review issue (squad:ralph + pending-review)
@@ -528,46 +546,48 @@ Ralph labels the issue:
 
 #### Release Criteria (Ralph's checklist)
 
-| Criteria | Weight |
-|----------|--------|
-| Contains user-facing features or enhancements? | High |
-| Contains breaking changes or migration steps? | High (forces release) |
-| Sufficient scope for a version bump? (≥3 features, or ≥1 significant feature) | Medium |
-| All CI gates green on `main`? | Gate (must be green) |
-| More than a hotfix / documentation / process change only? | Low |
+| Criteria                                                                      | Weight                |
+| ----------------------------------------------------------------------------- | --------------------- |
+| Contains user-facing features or enhancements?                                | High                  |
+| Contains breaking changes or migration steps?                                 | High (forces release) |
+| Sufficient scope for a version bump? (≥3 features, or ≥1 significant feature) | Medium                |
+| All CI gates green on `main`?                                                 | Gate (must be green)  |
+| More than a hotfix / documentation / process change only?                     | Low                   |
 
 **Default rule:** If in doubt, use `blog-only`. Releases should mark meaningful user-facing milestones.
 
 #### Version Bump Convention
 
-| Change type | Bump |
-|-------------|------|
-| Breaking API/schema change | `major` |
-| New user-facing features | `minor` |
+| Change type                  | Bump    |
+| ---------------------------- | ------- |
+| Breaking API/schema change   | `major` |
+| New user-facing features     | `minor` |
 | Bug fixes, perf, polish only | `patch` |
 
 To override the default `minor` bump, add a line to the review issue body:
-```
+
+```md
 bump: patch
 ```
+
 before applying the `release-candidate` label.
 
 #### Workflows Involved
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `milestone-blog.yml` | `milestone: closed` | Creates Ralph review issue |
-| `milestone-release-decision.yml` | Issue labeled `release-candidate` or `blog-only` | Routes to release or blog path |
-| `squad-milestone-release.yml` | `workflow_dispatch` | Creates tag + GitHub Release |
-| `release-blog.yml` | `release: published` | Creates Bilbo release blog brief |
-| `blog-readme-sync.yml` | `docs/blog/index.md` pushed to `main` | Updates README Dev Blog section |
+| Workflow                         | Trigger                                          | Purpose                          |
+| -------------------------------- | ------------------------------------------------ | -------------------------------- |
+| `milestone-blog.yml`             | `milestone: closed`                              | Creates Ralph review issue       |
+| `milestone-release-decision.yml` | Issue labeled `release-candidate` or `blog-only` | Routes to release or blog path   |
+| `squad-milestone-release.yml`    | `workflow_dispatch`                              | Creates tag + GitHub Release     |
+| `release-blog.yml`               | `release: published`                             | Creates Bilbo release blog brief |
+| `blog-readme-sync.yml`           | `docs/blog/index.md` pushed to `main`            | Updates README Dev Blog section  |
 
-#### Rules
+#### Rules final
 
-| Rule | Detail |
-|------|--------|
-| **Every milestone gets a blog post** | No exceptions — `blog-only` is the minimum outcome |
-| **Ralph owns the decision** | No other agent applies `release-candidate` or `blog-only` labels |
-| **The Page always updates** | Bilbo must always update `docs/blog/index.md` — the sync workflow does the rest |
-| **Release = blog post** | A GitHub Release always triggers a blog post via `release-blog.yml` |
-| **Ralph closes the review issue** | The decision workflow closes it automatically after routing |
+| Rule                                 | Detail                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------- |
+| **Every milestone gets a blog post** | No exceptions — `blog-only` is the minimum outcome                              |
+| **Ralph owns the decision**          | No other agent applies `release-candidate` or `blog-only` labels                |
+| **The Page always updates**          | Bilbo must always update `docs/blog/index.md` — the sync workflow does the rest |
+| **Release = blog post**              | A GitHub Release always triggers a blog post via `release-blog.yml`             |
+| **Ralph closes the review issue**    | The decision workflow closes it automatically after routing                     |

--- a/.squad/playbooks/pr-merge-process.md
+++ b/.squad/playbooks/pr-merge-process.md
@@ -1,0 +1,200 @@
+# PR Review & Merge Process Playbook
+
+**Owner:** Aragorn (Lead) + Ralph (Work Monitor)
+**Ref:** `.squad/ceremonies.md` (PR Review Gate, Standard Task Workflow)
+**Last Updated:** 2025-07-17
+
+---
+
+## Overview
+
+This playbook covers the end-to-end PR lifecycle: from opening a PR to squash-merging into `dev` (or `main`). Ralph monitors gates; Aragorn facilitates review; domain specialists provide parallel reviews.
+
+## Step 1 — Open the PR
+
+After pushing your branch (all pre-push gates passed):
+
+```bash
+gh pr create \
+  --base dev \
+  --title "feat(scope): description (#issue)" \
+  --body "Closes #<issue-number>
+
+## Changes
+- ...
+
+## Testing
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] Manual testing done
+
+## Checklist
+- [ ] Code follows conventions
+- [ ] Tests added/updated
+- [ ] Documentation updated (if needed)" \
+  --assignee @me
+```
+
+**Branch naming:** `squad/{issue-number}-{slug}` (enforced by routing.md)
+
+## Step 2 — Wait for CI
+
+Do NOT request review until CI is green:
+
+```bash
+# Poll CI status
+gh pr checks <PR-number>
+# All checks must show ✅ before proceeding
+```
+
+**If CI fails:** Fix on the same branch, push again (pre-push hook re-runs), wait for green.
+
+## Step 3 — Ralph's Pre-Review Gate
+
+Ralph MUST verify ALL of the following before spawning reviewers. Any failing gate blocks review:
+
+| Gate                | Command                                             | Expected                   |
+| ------------------- | --------------------------------------------------- | -------------------------- |
+| CI green            | `gh pr checks <N>`                                  | All passing                |
+| No conflicts        | `gh pr view <N> --json mergeable -q .mergeable`     | `MERGEABLE`                |
+| PR template filled  | `gh pr view <N> --json body`                        | Contains filled checkboxes |
+| Branch is `squad/*` | `gh pr view <N> --json headRefName -q .headRefName` | Starts with `squad/`       |
+
+## Step 4 — Spawn Reviewers
+
+Aragorn is ALWAYS required. Additional reviewers depend on files changed:
+
+| Files Changed                                                                             | Required Reviewer                    |
+| ----------------------------------------------------------------------------------------- | ------------------------------------ |
+| Any file                                                                                  | **Aragorn** (lead — always required) |
+| `.github/workflows/`, `AppHost.csproj`, `Directory.Packages.props`                        | **Boromir**                          |
+| `Auth/`, `appsettings*.json` auth sections, `Program.cs` auth, `UserManagementService.cs` | **Gandalf**                          |
+| `tests/Domain.Tests/`, `tests/Web.Tests.Bunit/`, `tests/Persistence.*/`                   | **Gimli**                            |
+| `tests/AppHost.Tests/` (Playwright / Aspire E2E)                                          | **Pippin**                           |
+| `src/Domain/`, `src/Persistence.*/`, `src/Web/Endpoints/`, `src/Web/Features/`            | **Sam**                              |
+| `src/Web/Components/`, `*.razor`, `*.razor.cs`, `*.razor.css`, `wwwroot/`                 | **Legolas**                          |
+| `docs/`, `README.md`, XML doc changes                                                     | **Frodo**                            |
+
+### Read Copilot Review First
+
+Before any reviewer posts their verdict, read GitHub Copilot's automated review:
+
+```bash
+gh pr view <N> --json reviews -q '.reviews[] | select(.author.login == "copilot-pull-request-reviewer") | .body'
+```
+
+Address any Copilot-flagged bugs, security issues, or logic errors. Style suggestions are discretionary.
+
+## Step 5 — Collect Verdicts
+
+- Spawn Aragorn + all required domain reviewers **in parallel**
+- Each reviewer posts a GitHub PR review:
+
+```bash
+# Approve
+gh pr review <N> --approve --body "LGTM — [summary]"
+# Request changes
+gh pr review <N> --request-changes --body "[specific issues]"
+```
+
+- **Unanimous approval required** — ALL spawned reviewers must approve
+
+## Step 6 — Handle CHANGES_REQUESTED
+
+If ANY reviewer requests changes:
+
+1. **Lockout rule:** The PR author is locked out of fixing in the same revision cycle
+2. Aragorn routes fixes to a DIFFERENT agent based on domain:
+   - Backend/logic → Sam
+   - Frontend/UI → Legolas
+   - Tests → Gimli / Pippin
+   - Security → Gandalf
+   - CI/infra → Boromir
+3. Fix agent pushes corrections to the **same branch** (no new PR)
+4. Wait for CI to re-pass
+5. Original reviewers re-review
+6. If approved → resume Step 7. If rejected again → repeat from Step 6
+
+### Comment Template (Aragorn posts on PR)
+
+```md
+🔄 **CHANGES_REQUESTED — Routing fix cycle**
+
+Reviewer: @{reviewer} requested changes.
+PR author (@{author}) is locked out of this revision cycle per rejection protocol.
+
+**Issues to fix:**
+{list from reviewer}
+
+**Routed to:** @{fix-agent} ({role})
+Fix agent: push corrections to `{branch}` and comment when ready for re-review.
+```
+
+## Step 7 — Squash Merge
+
+Once all reviewers approve and CI is green:
+
+```bash
+gh pr merge <N> --squash --delete-branch
+```
+
+**Commit message format** (conventional commits):
+
+```md
+feat(scope): description (#PR-number)
+
+- Bullet point changes
+- ...
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+## Step 8 — Post-Merge Cleanup
+
+Ralph triggers the Post-Merge Orphan Branch Cleanup ceremony:
+
+```bash
+# Sync local
+git checkout main && git pull origin main && git fetch --prune
+
+# Remove merged remote squad/ branches
+git branch -r --merged origin/main \
+  | grep 'origin/squad/' \
+  | sed 's|origin/||' \
+  | xargs -r -I{} git push origin --delete {}
+
+# Remove merged local squad/ branches
+git branch --merged main \
+  | grep -E '^\s+squad/' \
+  | xargs -r git branch -d
+
+# Remove local branches with deleted remotes
+git branch -vv \
+  | grep ': gone]' \
+  | grep 'squad/' \
+  | awk '{print $1}' \
+  | xargs -r git branch -D
+
+echo "✅ Orphan branch cleanup complete."
+```
+
+## Anti-Patterns
+
+- ❌ **Requesting review while CI is failing** — Wait for green first
+- ❌ **PR author fixing their own rejected code** — Lockout enforced per rejection protocol
+- ❌ **Merge commit instead of squash** — Use `--squash` for clean history
+- ❌ **Skipping Copilot review read** — Always check automated feedback first
+- ❌ **Leaving orphan branches** — Run cleanup after every merge
+- ❌ **Opening PR from `main` or `feature/`** — Must be from `squad/*` branch
+
+## Related Documents
+
+- **Full ceremonies:** `.squad/ceremonies.md` (PR Review Gate, CHANGES_REQUESTED, Post-Merge Orphan Branch Cleanup)
+- **Reviewer protocol skill:** `.copilot/skills/reviewer-protocol/SKILL.md`
+- **Merged PR guard skill:** `.copilot/skills/merged-pr-guard/SKILL.md`
+- **Routing:** `.squad/routing.md` (reviewer mapping)
+- **Pre-push playbook:** `.squad/playbooks/pre-push-process.md`
+
+---
+
+**Use this playbook for every PR.** Ralph enforces the gates automatically, but following this checklist ensures no steps are missed.

--- a/.squad/playbooks/pre-push-process.md
+++ b/.squad/playbooks/pre-push-process.md
@@ -1,0 +1,154 @@
+# Pre-Push Process Playbook
+
+**Owner:** Boromir (DevOps) + Aragorn (Lead)
+**Ref:** `.github/hooks/pre-push`, `CONTRIBUTING.md`
+**Last Updated:** 2025-07-17
+
+---
+
+## Overview
+
+The pre-push hook (`.github/hooks/pre-push`) enforces 5 gates that mirror CI. This playbook documents what agents must do before pushing and how to troubleshoot failures.
+
+## Pre-Flight Checklist (Before `git push`)
+
+Before running `git push`, verify:
+
+1. **You are on a `squad/*` branch** — Gate 0 blocks pushes to `main` and `dev`
+
+   ```bash
+   git symbolic-ref --short HEAD
+   # Must show: squad/{issue}-{slug}
+   ```
+
+2. **No untracked `.razor` or `.cs` files** — Gate 1 blocks these (invisible to CI)
+
+   ```bash
+   git ls-files --others --exclude-standard -- '*.razor' '*.cs'
+   # Must be empty. If files appear, stage them:
+   git add <files>
+   ```
+
+3. **Release build passes locally** — Gate 2 runs Release (not Debug)
+
+   ```bash
+   dotnet build IssueTrackerApp.slnx --configuration Release
+   ```
+
+   If build fails, run `.github/prompts/build-repair.prompt.md` to fix.
+
+4. **Unit tests pass** — Gate 3 runs 6 test projects
+
+   ```bash
+   dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --configuration Release --no-build
+   dotnet test tests/Domain.Tests/Domain.Tests.csproj --configuration Release --no-build
+   dotnet test tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj --configuration Release --no-build
+   dotnet test tests/Persistence.MongoDb.Tests/Persistence.MongoDb.Tests.csproj --configuration Release --no-build
+   dotnet test tests/Web.Tests/Web.Tests.csproj --configuration Release --no-build
+   dotnet test tests/Persistence.AzureStorage.Tests/Persistence.AzureStorage.Tests.csproj --configuration Release --no-build
+   ```
+
+5. **Docker is running** — Gate 4 requires Docker for integration tests
+
+   ```bash
+   docker info &>/dev/null && echo "Docker OK" || echo "Docker NOT running"
+   ```
+
+## The 5 Gates (What the Hook Runs)
+
+When you execute `git push`, the hook runs automatically:
+
+| Gate  | What                   | Blocks Push If                                                           |
+| ----- | ---------------------- | ------------------------------------------------------------------------ |
+| **0** | Branch protection      | Current branch is `main`                                                 |
+| **1** | Untracked source files | `.razor`/`.cs` files not staged (prompts y/N)                            |
+| **2** | Release build          | `dotnet build --configuration Release` fails (3 attempts)                |
+| **3** | Unit/Arch/bUnit tests  | Any of 6 test projects fail (3 attempts)                                 |
+| **4** | Integration tests      | Any of 4 integration test projects fail; Docker not running (3 attempts) |
+
+### Gate 3 — Test Projects (Unit)
+
+```text
+tests/Architecture.Tests/Architecture.Tests.csproj
+tests/Domain.Tests/Domain.Tests.csproj
+tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj
+tests/Persistence.MongoDb.Tests/Persistence.MongoDb.Tests.csproj
+tests/Web.Tests/Web.Tests.csproj
+tests/Persistence.AzureStorage.Tests/Persistence.AzureStorage.Tests.csproj
+```
+
+### Gate 4 — Integration Test Projects (Docker Required)
+
+```text
+tests/Persistence.MongoDb.Tests.Integration/Persistence.MongoDb.Tests.Integration.csproj
+tests/Web.Tests.Integration/Web.Tests.Integration.csproj
+tests/Persistence.AzureStorage.Tests.Integration/Persistence.AzureStorage.Tests.Integration.csproj
+tests/AppHost.Tests/AppHost.Tests.csproj
+```
+
+These use Testcontainers (mongo:7.0, Azurite) and Aspire DCP. Docker daemon MUST be running.
+
+## Retry Behavior
+
+The hook allows **3 attempts** for Gates 2, 3, and 4. Between attempts:
+
+- The hook pauses and prompts "Fix the errors and press Enter to retry, or Ctrl+C to abort"
+- Fix the failing code, then press Enter
+- The gate re-runs from scratch
+
+## Troubleshooting
+
+### Build Failure (Gate 2)
+
+| Symptom                  | Fix                                                   |
+| ------------------------ | ----------------------------------------------------- |
+| Warning treated as error | Fix the warning — `TreatWarningsAsErrors=true` is set |
+| Missing file reference   | Stage all new `.razor`/`.cs` files (Gate 1 issue)     |
+| NuGet restore failure    | Run `dotnet restore` manually first                   |
+
+**Escalation:** Run `.github/prompts/build-repair.prompt.md` for automated fix.
+
+### Test Failure (Gate 3)
+
+| Symptom                   | Fix                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Architecture test failure | Check naming conventions (commands → `Command`, queries → `Query`, handlers → `Handler`, validators → `Validator`) |
+| bUnit test failure        | Verify Blazor component rendering; check `Render<T>()` not `RenderComponent<T>()` (bUnit 2.x)                      |
+| DateTime equality failure | Assert individual fields, not whole-record equality (UtcNow varies between calls)                                  |
+
+### Integration Test Failure (Gate 4)
+
+| Symptom                   | Fix                                                             |
+| ------------------------- | --------------------------------------------------------------- |
+| Docker not running        | Start Docker Desktop or `sudo systemctl start docker`           |
+| Container startup timeout | Increase Docker resources; check `mongo:7.0` image is pulled    |
+| Connection string error   | Set `MONGODB_CONNECTION_STRING` env var if custom config needed |
+
+### Hook Not Installed
+
+The hook must be at `.git/hooks/pre-push`. The repo provides the hook at `.github/hooks/pre-push`. Install:
+
+```bash
+cp .github/hooks/pre-push .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+## Anti-Patterns
+
+- ❌ **Bypassing the hook** with `git push --no-verify` — CI will catch it, wasting time
+- ❌ **Running Debug build only** — CI uses Release; Debug hides missing files
+- ❌ **Pushing without Docker** — Gate 4 will block; start Docker first
+- ❌ **Ignoring untracked files** — They're invisible to CI and will cause failures
+- ❌ **Committing to `main` directly** — Gate 0 blocks this; use `squad/{issue}-{slug}` branches
+
+## Related Documents
+
+- **Hook source:** `.github/hooks/pre-push`
+- **Build repair:** `.github/prompts/build-repair.prompt.md`
+- **Contributing guide:** `CONTRIBUTING.md` (Pre-Push Gates section)
+- **Ceremonies:** `.squad/ceremonies.md` (Build Repair Check, Standard Task Workflow Phase 3)
+- **Skill:** `.copilot/skills/pre-push-test-gate/SKILL.md`
+
+---
+
+**Use this playbook every time you push.** The hook enforces these gates automatically, but understanding them helps you fix failures faster.

--- a/.squad/playbooks/release-issuetracker.md
+++ b/.squad/playbooks/release-issuetracker.md
@@ -1,7 +1,7 @@
 # Release Process — IssueTrackerApp Project Playbook
 
-**Last Updated:** 2026-04-12  
-**Ref:** `.squad/skills/release-process-base/SKILL.md`  
+**Last Updated:** 2025-07-17  
+**Ref:** `GitVersion.yml`, `.github/workflows/squad-release.yml`, `.github/workflows/squad-promote.yml`  
 **Project:** IssueTrackerApp  
 **Owner:** Boromir (DevOps) + Aragorn (Release Approval)
 
@@ -11,47 +11,56 @@
 
 ### Repository & Branches
 
-| Parameter | Value | Notes |
-|-----------|-------|-------|
-| **Owner** | mpaulosky | |
-| **Repo** | IssueTrackerApp | Single-owner fork (no upstream) |
-| **Dev Branch** | — | TBD: Use `main` (single-branch model) or create `dev`? |
-| **Release Branch** | main | Current default |
-| **Default Branch** | main | All PRs merge here |
+| Parameter          | Value           | Notes                                                          |
+| ------------------ | --------------- | -------------------------------------------------------------- |
+| **Owner**          | mpaulosky       |                                                                |
+| **Repo**           | IssueTrackerApp | Single-owner fork (no upstream)                                |
+| **Dev Branch**     | dev             | Integration branch — all squad PRs target dev (squash merge)   |
+| **Release Branch** | main            | Stable release branch — dev promotes to main via squad-promote |
+| **Default Branch** | main            | Protected; receives merges from dev only                       |
 
-**Decision:** IssueTrackerApp currently uses **single-branch model** (all work on `main`). Consider `dev` branch if/when team scales.
+**Decision:** IssueTrackerApp uses a **two-branch model** (dev + main). Squad branches (`squad/{issue}-{slug}`) target dev via squash merge. Promotion from dev → main uses the `squad-promote.yml` workflow with merge commits to preserve history.
 
 ### Version Management
 
-| Parameter | Value | Notes |
-|-----------|-------|-------|
-| **Version System** | NBGV | Nerdbank.GitVersioning |
-| **Version File** | `version.json` | At repo root |
-| **Tag Prefix** | `v` | e.g., `v1.0.0` |
-| **Package ID** | IssueTrackerApp | From `.csproj` |
-| **Merge Strategy** | merge | Preserve commit history on main |
+| Parameter          | Value                             | Notes                                                   |
+| ------------------ | --------------------------------- | ------------------------------------------------------- |
+| **Version System** | GitVersion                        | Configured in `GitVersion.yml`                          |
+| **Version File**   | `GitVersion.yml`                  | At repo root                                            |
+| **Tag Prefix**     | `v` / `V`                         | e.g., `v1.0.0` (both cases accepted per GitVersion.yml) |
+| **Package ID**     | IssueTrackerApp                   | From `.csproj`                                          |
+| **Merge Strategy** | squash (to dev), merge (dev→main) | Squash for feature work, merge commit for promotion     |
 
-**version.json reference:**
-```json
-{
-  "version": "1.0.0",
-  "publicReleaseRefSpec": [
-    "^refs/heads/main$",
-    "^refs/tags/v\\d+(?:\\.\\d+)?$"
-  ]
-}
+**GitVersion.yml reference** (actual repo config):
+
+```yaml
+mode: ContinuousDeployment
+tag-prefix: '[vV]?'
+branches:
+  main:
+    regex: ^main$
+    tag: ''
+    increment: Minor
+  develop:
+    regex: ^dev$
+    tag: preview
+    increment: Minor
+  feature:
+    regex: ^(feature|squad)[/-]
+    tag: alpha.{BranchName}
+    increment: Inherit
 ```
 
 ### Artifacts & Deployments
 
-| Artifact | Triggered By | Produced By | Deployed To |
-|----------|--------------|-------------|------------|
-| **Build Verification** | release published | `.github/workflows/build.yml` | (logs only) |
-| **Unit Tests** | release published | `.github/workflows/build.yml` | (logs only) |
-| **Integration Tests** | release published | `.github/workflows/integration-tests.yml` | (logs only) |
-| **Docker Image** | TBD | (not yet configured) | (not yet deployed) |
-| **Documentation** | TBD | (not yet configured) | (not yet deployed) |
-| **NuGet Package** | TBD | (not yet configured) | (not yet deployed) |
+| Artifact               | Triggered By      | Produced By                               | Deployed To        |
+| ---------------------- | ----------------- | ----------------------------------------- | ------------------ |
+| **Build Verification** | release published | `.github/workflows/build.yml`             | (logs only)        |
+| **Unit Tests**         | release published | `.github/workflows/build.yml`             | (logs only)        |
+| **Integration Tests**  | release published | `.github/workflows/integration-tests.yml` | (logs only)        |
+| **Docker Image**       | TBD               | (not yet configured)                      | (not yet deployed) |
+| **Documentation**      | TBD               | (not yet configured)                      | (not yet deployed) |
+| **NuGet Package**      | TBD               | (not yet configured)                      | (not yet deployed) |
 
 **Status:** Minimal release pipeline. Extend as needed.
 
@@ -61,37 +70,39 @@
 
 ### Prerequisites
 
-- [ ] All feature PRs merged to `main` (single-branch model)
-- [ ] `main` branch CI passing (build + tests green)
+- [ ] All feature PRs merged to `dev` (two-branch model)
+- [ ] `dev` branch CI passing (build + tests green)
+- [ ] Dev promoted to `main` via squad-promote workflow
+- [ ] `main` branch CI passing after promotion
 - [ ] No unmerged feature branches
 - [ ] Release notes prepared (in PR body or CHANGELOG.md)
 
-### Phase 1 — Version Bump
+### Phase 1 — Version Verification
 
-Since we use **NBGV**, version is auto-computed. To lock a release version:
+GitVersion auto-computes versions from branch and tags. Verify the computed version:
 
 ```bash
-# Edit version.json
-# Current version: 1.0.0
-# Release version: 1.0.0 (no bump if first release)
-# Next dev version: 1.0.1-preview (NBGV auto-increments after tag)
+# Check GitVersion output
+dotnet tool run dotnet-gitversion | grep -E '"(SemVer|FullSemVer|MajorMinorPatch)"'
 
-# Commit the bump (or skip if already correct)
-git add version.json
-git commit -m "Bump version to 1.0.0"
-git push origin main
+# Or use gittools/actions in CI — version is computed automatically
 ```
 
-**Note:** After release tag, NBGV will auto-increment to `1.0.1-preview.X` on main. No manual update needed.
+**Note:** No manual version file edits needed. GitVersion derives the version from git history, branch names, and tags.
 
 ### Phase 2 — Create Release PR
 
-**Skipped for single-branch model.** Release PR would merge `dev` → `main`, but since we use only `main`, just verify main is current:
+Promote `dev` to `main` using the squad-promote workflow:
 
 ```bash
-git fetch origin
+# Option A: Trigger via GitHub Actions
+gh workflow run squad-promote.yml
+
+# Option B: Manual merge (merge commit, not squash)
 git checkout main
-git reset --hard origin/main
+git pull origin main
+git merge --no-ff dev -m "chore: promote dev to main for release"
+git push origin main
 ```
 
 ### Phase 3 — Tag and Release
@@ -135,13 +146,14 @@ None
 
 ### Phase 4 — Verify CI/CD Pipeline
 
-Visit https://github.com/mpaulosky/IssueTrackerApp/releases/tag/v1.0.0 and confirm:
+Visit <https://github.com/mpaulosky/IssueTrackerApp/releases/tag/v1.0.0> and confirm:
 
 - ✅ **build.yml** job passed (Build + Unit Tests)
 - ✅ **integration-tests.yml** job passed (Playwright E2E)
 - ✅ No workflow failures
 
 **If any job fails:**
+
 ```bash
 # Delete tag and release
 git tag -d v1.0.0
@@ -164,8 +176,8 @@ git fetch origin
 git checkout main
 git reset --hard origin/main
 
-# Verify version.json auto-incremented (or manually bump to next dev version)
-git log -1 --format="%h %s"
+# Verify GitVersion computes next dev version
+dotnet tool run dotnet-gitversion | grep '"SemVer"'
 
 # Document in CHANGELOG.md (optional)
 echo "## v1.0.0 ($(date +%Y-%m-%d))" >> CHANGELOG.md
@@ -182,20 +194,21 @@ git push origin main
 
 ### Issue: Build Fails on Release Tag
 
-**Symptom:** `v1.0.0` tag created, but build.yml workflow fails
+**Symptom:** `v1.0.0` tag created, but build workflow fails
 
-**Root Cause:** .csproj or build script expects `version.json` in a specific location
+**Root Cause:** GitVersion configuration mismatch or tag prefix issue
 
 **Fix:**
+
 ```bash
-# Verify version.json is at repo root
-ls -la version.json
+# Verify GitVersion.yml exists at repo root
+ls -la GitVersion.yml
 
-# Check .csproj includes NBGV reference
-grep -i "nbgv" Directory.Build.props
+# Check tag prefix matches GitVersion config (v or V)
+git tag -l 'v*' | head -5
 
-# If NBGV removed for release (per release.yml logic), manually verify version
-dotnet build -p:Version=1.0.0
+# Verify GitVersion can compute version from current state
+dotnet tool run dotnet-gitversion
 ```
 
 ### Issue: Integration Tests Timeout on Release
@@ -205,6 +218,7 @@ dotnet build -p:Version=1.0.0
 **Root Cause:** Playwright E2E test is slow; needs optimization or longer timeout
 
 **Fix:** Contact Pippin (Tester E2E). May need to:
+
 - Increase GitHub Actions timeout
 - Skip E2E on release tags (if desired)
 - Parallelize E2E tests
@@ -221,13 +235,14 @@ dotnet build -p:Version=1.0.0
 
 ## Secrets & Permissions
 
-| Secret | Used By | Type | Status |
-|--------|---------|------|--------|
-| `GITHUB_TOKEN` | CI/CD (auto-provided) | Built-in | ✅ Active |
-| `NUGET_API_KEY` | (not used yet) | Manual | ⏸️ Not configured |
-| `AZURE_WEBAPP_WEBHOOK_URL` | (not used yet) | Manual | ⏸️ Not configured |
+| Secret                     | Used By               | Type     | Status           |
+| -------------------------- | --------------------- | -------- | ---------------- |
+| `GITHUB_TOKEN`             | CI/CD (auto-provided) | Built-in | ✅ Active         |
+| `NUGET_API_KEY`            | (not used yet)        | Manual   | ⏸️ Not configured |
+| `AZURE_WEBAPP_WEBHOOK_URL` | (not used yet)        | Manual   | ⏸️ Not configured |
 
 **To Deploy Docker or NuGet Packages:**
+
 1. Contact Boromir (DevOps)
 2. Configure secrets in GitHub
 3. Update release workflow to include new jobs
@@ -239,17 +254,18 @@ dotnet build -p:Version=1.0.0
 - [ ] **Docker Image Publishing:** Add `publish-container.yml` when container deployment is needed
 - [ ] **NuGet Package Publishing:** Add `publish-nuget.yml` + configure `NUGET_API_KEY` secret
 - [ ] **Documentation Deployment:** Add `docs.yml` when GitHub Pages docs site is ready
-- [ ] **Multi-Branch Model:** Consider `dev` branch when team grows beyond single owner
+- [ ] **Release Branches:** Consider `release/*` branches for hotfix isolation if needed
 - [ ] **Automated Release Notes:** Script CHANGELOG.md generation from PR titles
 
 ---
 
 ## Reference
 
-- **Generic Skill:** `.squad/skills/release-process-base/SKILL.md`
-- **Decision:** `.squad/decisions/inbox/aragorn-release-process-generic.md`
-- **Current Workflows:** `.github/workflows/build.yml`, `integration-tests.yml`, `push` triggers
-- **GitHub Docs:** https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
+- **GitVersion config:** `GitVersion.yml`
+- **Release workflow:** `.github/workflows/squad-release.yml`
+- **Promote workflow:** `.github/workflows/squad-promote.yml`
+- **CI workflow:** `.github/workflows/squad-ci.yml`
+- **GitHub Docs:** <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>
 
 **Owner for Updates:** Aragorn (Lead) + Boromir (DevOps)  
 **Last Reviewed:** 2026-04-12

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -2,42 +2,42 @@
 
 ## Signal → Agent
 
-| Signal | Agent | Notes |
-|--------|-------|-------|
-| /plan, plan mode, [[PLAN]] | Aragorn | Lead runs Plan Ceremony after plan.md is approved |
-| Architecture, scope, decisions, code review, PR review | Aragorn | Lead |
-| Blazor, Razor, UI, frontend, components, CSS | Legolas | Frontend |
-| RoleBadge, EditUserRolesModal, UserAuditLogPanel, UserListTable components | Legolas | Frontend — admin UI components |
-| LabelInput component, label filter chips, label autocomplete, multi-value input | Legolas | Frontend — LabelInput component |
-| MongoDB, repositories, API endpoints, backend services, MediatR handlers | Sam | Backend |
-| Admin user management, UserManagementService, Auth0 Management API, admin roles, /admin/users | Sam | Backend — admin user CQRS handlers |
-| Labels, label filtering, AddLabelCommand, RemoveLabelCommand, ILabelService | Sam | Backend — Labels CQRS + service |
-| Unit tests, bUnit, MongoDB integration tests, test quality review | Gimli | Tester |
-| Playwright E2E tests, Aspire integration tests, test infrastructure | Pippin | Tester (E2E) |
-| CI/CD, GitHub Actions, NuGet, deployment, Aspire infra, protected branch | Boromir | DevOps |
-| Docs, README, XML docs, comments, CONTRIBUTING | Frodo | Docs |
-| Blog posts, GitHub Pages, project announcements, changelog posts, feature write-ups | Bilbo | Tech Blogger |
-| Auth0, authentication, authorization, JWT, RBAC, security audit, vulnerabilities, injection, XSS, CSRF, secrets, HTTPS, CORS, security headers, security review | Gandalf | Security |
-| Auth0 Management API, management client, ManagementApiClient | Gandalf | Security review of management API usage |
-| admin role assignment, role revocation, user role management | Gandalf | Auth security — admin operations |
-| ResultErrorCode.ExternalService, external API failures | Gandalf + Sam | Auth0 error wrapping patterns |
-| GitHub board, issues, PRs, backlog, work queue | Ralph | Work Monitor |
-| Session log, orchestration log, history summarization, decisions archival, memory sweep | Scribe | Memory management |
-| PR with reviewDecision: CHANGES_REQUESTED | Aragorn | Lead routes fix to non-author agent |
-| PR with mergeable: CONFLICTED | Aragorn | Lead determines resolver by file domain |
-| PR with statusCheckRollup: FAILURE | Boromir + author agent | CI failure: Boromir diagnoses, author fixes |
-| PR ready for review (CI green, no conflicts) | Aragorn + domain reviewers | Spawn per files-changed table in ceremonies.md |
-| Untriaged issues (squad label, no squad:* sub-label) | Aragorn | Lead triages |
-| squad:aragorn | Aragorn | — |
-| squad:legolas | Legolas | — |
-| squad:sam | Sam | — |
-| squad:gimli | Gimli | — |
-| squad:pippin | Pippin | — |
-| squad:boromir | Boromir | — |
-| squad:frodo | Frodo | — |
-| squad:bilbo | Bilbo | — |
-| squad:gandalf | Gandalf | — |
-| squad:copilot | @copilot | Auto-assign: false |
+| Signal                                                                                                                                                          | Agent                      | Notes                                             |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------- |
+| /plan, plan mode, [[PLAN]]                                                                                                                                      | Aragorn                    | Lead runs Plan Ceremony after plan.md is approved |
+| Architecture, scope, decisions, code review, PR review                                                                                                          | Aragorn                    | Lead                                              |
+| Blazor, Razor, UI, frontend, components, CSS                                                                                                                    | Legolas                    | Frontend                                          |
+| RoleBadge, EditUserRolesModal, UserAuditLogPanel, UserListTable components                                                                                      | Legolas                    | Frontend — admin UI components                    |
+| LabelInput component, label filter chips, label autocomplete, multi-value input                                                                                 | Legolas                    | Frontend — LabelInput component                   |
+| MongoDB, repositories, API endpoints, backend services, MediatR handlers                                                                                        | Sam                        | Backend                                           |
+| Admin user management, UserManagementService, Auth0 Management API, admin roles, /admin/users                                                                   | Sam                        | Backend — admin user CQRS handlers                |
+| Labels, label filtering, AddLabelCommand, RemoveLabelCommand, ILabelService                                                                                     | Sam                        | Backend — Labels CQRS + service                   |
+| Unit tests, bUnit, MongoDB integration tests, test quality review                                                                                               | Gimli                      | Tester                                            |
+| Playwright E2E tests, Aspire integration tests, test infrastructure                                                                                             | Pippin                     | Tester (E2E)                                      |
+| CI/CD, GitHub Actions, NuGet, deployment, Aspire infra, protected branch                                                                                        | Boromir                    | DevOps                                            |
+| Docs, README, XML docs, comments, CONTRIBUTING                                                                                                                  | Frodo                      | Docs                                              |
+| Blog posts, GitHub Pages, project announcements, changelog posts, feature write-ups                                                                             | Bilbo                      | Tech Blogger                                      |
+| Auth0, authentication, authorization, JWT, RBAC, security audit, vulnerabilities, injection, XSS, CSRF, secrets, HTTPS, CORS, security headers, security review | Gandalf                    | Security                                          |
+| Auth0 Management API, management client, ManagementApiClient                                                                                                    | Gandalf                    | Security review of management API usage           |
+| admin role assignment, role revocation, user role management                                                                                                    | Gandalf                    | Auth security — admin operations                  |
+| ResultErrorCode.ExternalService, external API failures                                                                                                          | Gandalf + Sam              | Auth0 error wrapping patterns                     |
+| GitHub board, issues, PRs, backlog, work queue                                                                                                                  | Ralph                      | Work Monitor                                      |
+| Session log, orchestration log, history summarization, decisions archival, memory sweep                                                                         | Scribe                     | Memory management                                 |
+| PR with reviewDecision: CHANGES_REQUESTED                                                                                                                       | Aragorn                    | Lead routes fix to non-author agent               |
+| PR with mergeable: CONFLICTED                                                                                                                                   | Aragorn                    | Lead determines resolver by file domain           |
+| PR with statusCheckRollup: FAILURE                                                                                                                              | Boromir + author agent     | CI failure: Boromir diagnoses, author fixes       |
+| PR ready for review (CI green, no conflicts)                                                                                                                    | Aragorn + domain reviewers | Spawn per files-changed table in ceremonies.md    |
+| Untriaged issues (squad label, no squad:* sub-label)                                                                                                            | Aragorn                    | Lead triages                                      |
+| squad:aragorn                                                                                                                                                   | Aragorn                    | —                                                 |
+| squad:legolas                                                                                                                                                   | Legolas                    | —                                                 |
+| squad:sam                                                                                                                                                       | Sam                        | —                                                 |
+| squad:gimli                                                                                                                                                     | Gimli                      | —                                                 |
+| squad:pippin                                                                                                                                                    | Pippin                     | —                                                 |
+| squad:boromir                                                                                                                                                   | Boromir                    | —                                                 |
+| squad:frodo                                                                                                                                                     | Frodo                      | —                                                 |
+| squad:bilbo                                                                                                                                                     | Bilbo                      | —                                                 |
+| squad:gandalf                                                                                                                                                   | Gandalf                    | —                                                 |
+| squad:copilot                                                                                                                                                   | @copilot                   | Auto-assign: false                                |
 
 ## Branching Policy
 
@@ -45,10 +45,22 @@
 - NEVER commit `.squad/` files on `feature/*` branches — guard will block the PR
 - Scribe commits `.squad/` changes on `squad/*` branches only
 
-## Skill-Aware Routing
+## Playbook-Aware Routing
 
-Before spawning any agent, check `.squad/skills/` for relevant skills:
+Before spawning any agent, check playbooks and skills for relevant procedures:
 
-- Any push/commit work → `.squad/skills/pre-push-test-gate/SKILL.md`
-- Any build/test failure → `.github/prompts/build-repair.prompt.md`
-- Any integration test work → `.squad/skills/pre-push-test-gate/SKILL.md` (Integration section)
+### Playbooks (step-by-step execution)
+
+- Any push/commit work → `.squad/playbooks/pre-push-process.md`
+- PR ready for merge → `.squad/playbooks/pr-merge-process.md`
+- Release preparation → `.squad/playbooks/release-issuetracker.md`
+
+### Skills (knowledge / troubleshooting)
+
+- Pre-push gate details → `.copilot/skills/pre-push-test-gate/SKILL.md`
+- Build/test failure → `.github/prompts/build-repair.prompt.md`
+- PR review protocol → `.copilot/skills/reviewer-protocol/SKILL.md`
+- Merged PR guard → `.copilot/skills/merged-pr-guard/SKILL.md`
+- Git workflow/branching → `.copilot/skills/git-workflow/SKILL.md`
+
+> ⚠️ Skills prefixed with "Squad CLI Only" (`squad-conventions`, `ci-validation-gates`, `release-process`) are for the Squad npm package, NOT IssueTrackerApp.


### PR DESCRIPTION
## Summary

Formalizes pre-push and merge processes into agent-executable playbooks and fixes stale/contradictory documentation.

### New Playbooks
- **`.squad/playbooks/pre-push-process.md`** — Full 5-gate pre-push walkthrough with pre-flight checklist, troubleshooting, and Docker requirements
- **`.squad/playbooks/pr-merge-process.md`** — 8-step PR merge lifecycle (open → CI → gate → review → merge → cleanup)

### Fixed / Rewritten
- **`.copilot/skills/pre-push-test-gate/SKILL.md`** — Complete rewrite covering all 5 gates, 10 test projects, retry behavior
- **`.squad/playbooks/release-issuetracker.md`** — Fixed 12+ contradictions (NBGV→GitVersion, single→two-branch model)

### Flagged as Squad CLI Only
- `squad-conventions`, `ci-validation-gates`, `release-process` — ⚠️ warnings so agents don't follow Node.js/npm patterns

### Config Updated
- **`.squad/routing.md`** — New "Playbook-Aware Routing" section replacing stale skill references
- **`.squad/ceremonies.md`** — Playbook cross-references added to Build Repair Check, PR Review Gate, Standard Task Workflow

### Test Results
All 5 pre-push gates passed: 0 warnings, **2,365 tests** (2,026 unit + 339 integration) ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>