### PR TITLE
fix: upgrade gittools/actions to v4.5.0 for GitVersion 6.7.0 compat

### DIFF
--- a/.github/workflows/squad-insider-release.yml
+++ b/.github/workflows/squad-insider-release.yml
@@ -21,13 +21,13 @@ jobs:
           global-json-file: global.json
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
           versionSpec: '6.x'
 
       - name: Determine version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3
+        uses: gittools/actions/gitversion/execute@v4.5.0
         with:
           useConfigFile: true
           configFilePath: GitVersion.yml

--- a/.github/workflows/squad-milestone-release.yml
+++ b/.github/workflows/squad-milestone-release.yml
@@ -33,13 +33,13 @@ jobs:
           global-json-file: global.json
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
           versionSpec: '6.x'
 
       - name: Determine current version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3
+        uses: gittools/actions/gitversion/execute@v4.5.0
         with:
           useConfigFile: true
           configFilePath: GitVersion.yml

--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -34,13 +34,13 @@ jobs:
           global-json-file: global.json
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3.1.11
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
           versionSpec: '6.x'
 
       - name: Determine version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.1.11
+        uses: gittools/actions/gitversion/execute@v4.5.0
         with:
           useConfigFile: true
 

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -21,13 +21,13 @@ jobs:
           global-json-file: global.json
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
           versionSpec: '6.x'
 
       - name: Determine version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3
+        uses: gittools/actions/gitversion/execute@v4.5.0
         with:
           useConfigFile: true
           configFilePath: GitVersion.yml


### PR DESCRIPTION
## Problem
The squad-promote workflow failed because `gittools/actions@v3.1.11` only supports GitVersion `>=5.2.0 <6.1.0`, but `versionSpec: '6.x'` now resolves to **6.7.0**.

## Fix
Upgrade all 4 release workflows from `gittools/actions@v3` / `@v3.1.11` to `@v4.5.0`:
- `squad-promote.yml`
- `squad-milestone-release.yml`
- `squad-release.yml`
- `squad-insider-release.yml`

Output variables (`semVer`, `major`, `minor`, `patch`, `assemblySemVer`, `assemblySemFileVer`) are unchanged in v4.

## After merge
Re-run the **Squad Promote** workflow to open the dev → main PR.