### PR TITLE
chore: ignore *.csproj.lscache LSP artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,6 +387,7 @@ MigrationBackup/
 
 # IDE / local
 .vscode/
+*.csproj.lscache
 
 # Test output
 coverage/


### PR DESCRIPTION
Adds `*.csproj.lscache` pattern to `.gitignore` to suppress 16 untracked LSP artifact files generated by the C# language server.

These files are build/IDE artifacts and should never be committed.

---
🤖 Ralph (Work Monitor) — housekeeping chore