### PR TITLE
fix: stabilize preview validation and upgrade workflow runtimes

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 

--- a/.github/workflows/squad-preview.yml
+++ b/.github/workflows/squad-preview.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 

--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 

--- a/src/Web/Services/SignalRClientService.cs
+++ b/src/Web/Services/SignalRClientService.cs
@@ -8,6 +8,7 @@
 // =======================================================
 
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Hosting;
 
 using Web.Services;
 
@@ -20,17 +21,21 @@ public sealed class SignalRClientService : IAsyncDisposable
 {
 	private readonly ILogger<SignalRClientService> _logger;
 	private readonly ToastService _toastService;
+	private readonly IHostEnvironment _hostEnvironment;
 	private readonly NavigationManager _navigationManager;
 	private HubConnection? _hubConnection;
 	private bool _isStarted;
+	private bool _startupSkipped;
 
 	public SignalRClientService(
 		ILogger<SignalRClientService> logger,
 		ToastService toastService,
+		IHostEnvironment hostEnvironment,
 		NavigationManager navigationManager)
 	{
 		_logger = logger;
 		_toastService = toastService;
+		_hostEnvironment = hostEnvironment;
 		_navigationManager = navigationManager;
 	}
 
@@ -86,6 +91,17 @@ public sealed class SignalRClientService : IAsyncDisposable
 	{
 		if (_isStarted)
 		{
+			return;
+		}
+
+		if (_hostEnvironment.IsEnvironment("IntegrationTesting"))
+		{
+			if (!_startupSkipped)
+			{
+				_startupSkipped = true;
+				_logger.LogInformation("Skipping SignalR client startup in IntegrationTesting");
+			}
+
 			return;
 		}
 

--- a/tests/Web.Tests.Bunit/BunitTestBase.cs
+++ b/tests/Web.Tests.Bunit/BunitTestBase.cs
@@ -15,6 +15,7 @@ using Domain.Features.Admin.Users.Queries;
 using MediatR;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 
 using Web.Auth;
@@ -84,11 +85,15 @@ public abstract class BunitTestBase : BunitContext
 		// Register concrete services required by page components
 		var toastService = new ToastService();
 		var fakeNav = new FakeNavigationManager();
+		var hostEnvironment = Substitute.For<IHostEnvironment>();
+		hostEnvironment.EnvironmentName.Returns("IntegrationTesting");
 		Services.AddSingleton(toastService);
+		Services.AddSingleton(hostEnvironment);
 		Services.AddSingleton(new BulkSelectionState());
 		Services.AddSingleton(new SignalRClientService(
 			NullLogger<SignalRClientService>.Instance,
 			toastService,
+			hostEnvironment,
 			fakeNav));
 
 		// Set up sensible default returns for common services so that

--- a/tests/Web.Tests/Services/SignalRClientServiceTests.cs
+++ b/tests/Web.Tests/Services/SignalRClientServiceTests.cs
@@ -9,6 +9,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Web.Services;
 
@@ -31,6 +32,7 @@ public sealed class SignalRClientServiceTests : IAsyncDisposable
 		_sut = new SignalRClientService(
 			NullLogger<SignalRClientService>.Instance,
 			_toastService,
+			CreateHostEnvironment(),
 			_navigationManager);
 	}
 
@@ -193,6 +195,26 @@ public sealed class SignalRClientServiceTests : IAsyncDisposable
 	}
 
 	[Fact]
+	public async Task StartAsync_WhenIntegrationTesting_SkipsConnectionAttempt()
+	{
+		// Arrange
+		var service = new SignalRClientService(
+			NullLogger<SignalRClientService>.Instance,
+			_toastService,
+			CreateHostEnvironment("IntegrationTesting"),
+			_navigationManager);
+
+		// Act
+		await service.StartAsync();
+
+		// Assert
+		service.ConnectionState.Should().Be(HubConnectionState.Disconnected);
+		_toastService.Toasts.Should().BeEmpty();
+
+		await service.DisposeAsync();
+	}
+
+	[Fact]
 	public async Task StartAsync_WhenCalledTwice_ReturnsEarlyOnSecondCall()
 	{
 		// Arrange
@@ -283,6 +305,7 @@ public sealed class SignalRClientServiceTests : IAsyncDisposable
 		var service = new SignalRClientService(
 			NullLogger<SignalRClientService>.Instance,
 			_toastService,
+			CreateHostEnvironment(),
 			_navigationManager);
 
 		// Act
@@ -299,6 +322,7 @@ public sealed class SignalRClientServiceTests : IAsyncDisposable
 		var service = new SignalRClientService(
 			NullLogger<SignalRClientService>.Instance,
 			_toastService,
+			CreateHostEnvironment(),
 			_navigationManager);
 		await service.StartAsync();
 
@@ -311,6 +335,13 @@ public sealed class SignalRClientServiceTests : IAsyncDisposable
 
 		// Assert
 		await act.Should().NotThrowAsync();
+	}
+
+	private static IHostEnvironment CreateHostEnvironment(string environmentName = "Production")
+	{
+		var hostEnvironment = Substitute.For<IHostEnvironment>();
+		hostEnvironment.EnvironmentName.Returns(environmentName);
+		return hostEnvironment;
 	}
 
 	#endregion


### PR DESCRIPTION
## Summary
- skip SignalR client startup in the IntegrationTesting environment to stop preview validation from failing on localhost:80 connection attempts
- add unit coverage for the integration-test no-op path and align the bUnit SignalR client setup
- upgrade remaining `actions/setup-dotnet` workflows from v4 to v5 so they run on the Node 24-compatible action runtime

## Testing
- [x] `dotnet restore IssueTrackerApp.slnx`
- [x] `dotnet build IssueTrackerApp.slnx --configuration Release --no-restore -p:TreatWarningsAsErrors=true`
- [x] `dotnet test IssueTrackerApp.slnx --configuration Release --no-build --verbosity normal`