### PR TITLE
fix: split squad preview test execution

### DIFF
--- a/.github/workflows/squad-preview.yml
+++ b/.github/workflows/squad-preview.yml
@@ -29,4 +29,16 @@ jobs:
         run: pwsh tests/AppHost.Tests/bin/Release/net10.0/playwright.ps1 install chromium --with-deps
 
       - name: Run unit tests
-        run: dotnet test IssueTrackerApp.slnx --configuration Release --no-build --verbosity normal
+        run: |
+          # Run all tests EXCEPT AppHost.Tests (which needs separate Aspire orchestrator isolation)
+          dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Domain.Tests/Domain.Tests.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Persistence.MongoDb.Tests/Persistence.MongoDb.Tests.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Web.Tests/Web.Tests.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Persistence.AzureStorage.Tests/Persistence.AzureStorage.Tests.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Persistence.MongoDb.Tests.Integration/Persistence.MongoDb.Tests.Integration.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Web.Tests.Integration/Web.Tests.Integration.csproj --configuration Release --no-build --verbosity normal
+          dotnet test tests/Persistence.AzureStorage.Tests.Integration/Persistence.AzureStorage.Tests.Integration.csproj --configuration Release --no-build --verbosity normal
+          # AppHost.Tests run separately to avoid Aspire orchestrator cleanup issues with monolithic solution-level test
+          dotnet test tests/AppHost.Tests/AppHost.Tests.csproj --configuration Release --no-build --verbosity normal


### PR DESCRIPTION
## Summary
- replace the monolithic `dotnet test IssueTrackerApp.slnx` preview step with per-project test commands
- run AppHost/Aspire Playwright tests in isolated test-project execution instead of inside the solution-wide VSTest process
- keep restore/build/browser install behavior unchanged while making preview failures map to a specific test project

## Root cause
After merging #272, the `dev` branch `squad-preview.yml` run (`25236059974`) still failed even though the log reported all tests passed. The failure came from the single solution-wide `dotnet test IssueTrackerApp.slnx` step in preview. Splitting the preview workflow to execute each test project individually matches the already-working CI pattern and avoids the false failing solution-level exit path.

## Testing
- [x] pre-push gate passed
- [x] Release build
- [x] unit test projects
- [x] integration test projects
- [x] `tests/AppHost.Tests/AppHost.Tests.csproj`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>