### PR TITLE
M3: GridFS Integration Tests — Replace Azurite Coverage

### DIFF
--- a/.github/workflows/squad-test.yml
+++ b/.github/workflows/squad-test.yml
@@ -496,6 +496,80 @@ jobs:
           name: persistence-mongodb-integration-test-results
           path: test-results
 
+  test-gridfs-integration:
+    name: "Persistence.MongoDb.Tests.GridFs.Integration"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+
+    env:
+      MONGODB_CONNECTION_STRING: "mongodb://localhost:27017/?directConnection=true"
+
+    steps:
+      - name: Start MongoDB Replica Set
+        run: |
+          docker run -d --name mongodb -p 27017:27017 mongo:7.0 mongod --replSet rs0
+          # Wait for MongoDB to be ready
+          for i in {1..30}; do
+            if docker exec mongodb mongosh --quiet --eval "db.runCommand({ ping: 1 })" 2>/dev/null; then
+              echo "MongoDB is accepting connections"
+              break
+            fi
+            echo "Waiting for MongoDB... attempt $i"
+            sleep 2
+          done
+          # Initialize single-node replica set
+          docker exec mongodb mongosh --quiet --eval "rs.initiate({_id: 'rs0', members: [{_id: 0, host: 'localhost:27017'}]})"
+          # Wait for replica set to elect primary
+          for i in {1..30}; do
+            if docker exec mongodb mongosh --quiet --eval "rs.isMaster().ismaster" 2>/dev/null | grep -q true; then
+              echo "Replica set primary is ready"
+              break
+            fi
+            echo "Waiting for primary... attempt $i"
+            sleep 2
+          done
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build GridFS Integration Tests
+        run: dotnet build tests/Persistence.MongoDb.Tests.GridFs.Integration --configuration Release --no-restore
+
+      - name: Run GridFS Integration Tests
+        run: |
+          mkdir -p test-results
+          dotnet test tests/Persistence.MongoDb.Tests.GridFs.Integration \
+            --configuration Release \
+            --no-build \
+            --verbosity normal \
+            --logger "trx;LogFileName=gridfs-integration.trx" \
+            --results-directory "$GITHUB_WORKSPACE/test-results" \
+            --collect:"XPlat Code Coverage"
+
+      - name: Upload GridFS Integration Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: gridfs-integration-test-results
+          path: test-results
+
   test-apphost:
     name: "AppHost.Tests (Aspire + Playwright E2E)"
     runs-on: ubuntu-latest
@@ -571,6 +645,7 @@ jobs:
       - test-integration
       - test-persistence-mongodb
       - test-persistence-mongodb-integration
+      - test-gridfs-integration
       - test-apphost
     if: always()
 
@@ -644,6 +719,7 @@ jobs:
       - test-integration
       - test-persistence-mongodb
       - test-persistence-mongodb-integration
+      - test-gridfs-integration
       - test-apphost
     if: always()
 
@@ -680,6 +756,7 @@ jobs:
           echo "- **Web.Tests.Integration:** ${{ needs.test-integration.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Persistence.MongoDb.Tests:** ${{ needs.test-persistence-mongodb.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Persistence.MongoDb.Tests.Integration:** ${{ needs.test-persistence-mongodb-integration.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Persistence.MongoDb.Tests.GridFs.Integration:** ${{ needs.test-gridfs-integration.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **AppHost.Tests (Aspire + Playwright E2E):** ${{ needs.test-apphost.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
@@ -696,12 +773,13 @@ jobs:
           integration_status="${{ needs.test-integration.result }}"
           mongodb_status="${{ needs.test-persistence-mongodb.result }}"
           mongodb_int_status="${{ needs.test-persistence-mongodb-integration.result }}"
+          gridfs_status="${{ needs.test-gridfs-integration.result }}"
           apphost_status="${{ needs.test-apphost.result }}"
 
           if [[ "$build_status" == "failure" || "$domain_status" == "failure" || "$web_status" == "failure" || \
                 "$arch_status" == "failure" || "$bunit_status" == "failure" || \
                 "$integration_status" == "failure" || "$mongodb_status" == "failure" || \
-                "$mongodb_int_status" == "failure" || \
+                "$mongodb_int_status" == "failure" || "$gridfs_status" == "failure" || \
                 "$apphost_status" == "failure" ]]; then
             echo "❌ **Overall Status:** FAILED" >> $GITHUB_STEP_SUMMARY
           else

--- a/IssueTrackerApp.slnx
+++ b/IssueTrackerApp.slnx
@@ -15,6 +15,7 @@
     <Project Path="tests/Persistence.AzureStorage.Tests.Integration/Persistence.AzureStorage.Tests.Integration.csproj" />
     <Project Path="tests/Persistence.MongoDb.Tests/Persistence.MongoDb.Tests.csproj" />
     <Project Path="tests/Persistence.MongoDb.Tests.Integration/Persistence.MongoDb.Tests.Integration.csproj" />
+    <Project Path="tests/Persistence.MongoDb.Tests.GridFs.Integration/Persistence.MongoDb.Tests.GridFs.Integration.csproj" />
     <Project Path="tests/Web.Tests.Bunit/Web.Tests.Bunit.csproj" />
     <Project Path="tests/Web.Tests.Integration/Web.Tests.Integration.csproj" />
     <Project Path="tests/Web.Tests/Web.Tests.csproj" />

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/GlobalUsings.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/GlobalUsings.cs
@@ -1,0 +1,23 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GlobalUsings.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+global using System;
+global using System.IO;
+global using System.Linq;
+global using System.Threading;
+global using System.Threading.Tasks;
+global using Domain.Models;
+global using FluentAssertions;
+global using Microsoft.Extensions.Logging.Abstractions;
+global using MongoDB.Driver;
+global using Persistence.MongoDb.Services;
+global using SixLabors.ImageSharp;
+global using SixLabors.ImageSharp.PixelFormats;
+global using Testcontainers.MongoDb;
+global using Xunit;

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageConcurrencyTests.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageConcurrencyTests.cs
@@ -1,0 +1,144 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GridFsStorageConcurrencyTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+namespace Persistence.MongoDb.Tests.GridFs.Integration;
+
+/// <summary>
+///   Integration tests for GridFsStorageService concurrent operations.
+/// </summary>
+[Collection("GridFsIntegration")]
+public sealed class GridFsStorageConcurrencyTests
+{
+	private readonly MongoDbGridFsFixture _fixture;
+
+	public GridFsStorageConcurrencyTests(MongoDbGridFsFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithMultipleConcurrentUploads_ShouldAllSucceed()
+	{
+		// Arrange
+		var uploadTasks = Enumerable.Range(0, 10)
+			.Select(i =>
+			{
+				var service = _fixture.CreateGridFsStorageService();
+				var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"Concurrent upload {i}"));
+				return service.UploadAsync(content, $"concurrent-{i}.txt", "text/plain");
+			})
+			.ToList();
+
+		// Act
+		var blobUrls = await Task.WhenAll(uploadTasks);
+
+		// Assert
+		blobUrls.Should().HaveCount(10);
+		blobUrls.Should().OnlyHaveUniqueItems();
+		blobUrls.Should().AllSatisfy(url => url.Should().NotBeNullOrEmpty());
+	}
+
+	[Fact]
+	public async Task UploadAsync_ConcurrentUploadsToSameDatabase_ShouldAllSucceed()
+	{
+		// Arrange — all tasks share the same service instance
+		var service = _fixture.CreateGridFsStorageService();
+
+		// Act
+		var uploadTasks = Enumerable.Range(0, 10)
+			.Select(i =>
+			{
+				var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"Container test {i}"));
+				return service.UploadAsync(content, $"same-db-{i}.txt", "text/plain");
+			})
+			.ToList();
+
+		var blobUrls = await Task.WhenAll(uploadTasks);
+
+		// Assert
+		blobUrls.Should().HaveCount(10);
+		blobUrls.Should().OnlyHaveUniqueItems();
+	}
+
+	[Fact]
+	public async Task DownloadAsync_ConcurrentDownloads_ShouldAllSucceed()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+
+		var blobUrls = await Task.WhenAll(Enumerable.Range(0, 5)
+			.Select(i =>
+			{
+				var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"Download test {i}"));
+				return service.UploadAsync(content, $"download-{i}.txt", "text/plain");
+			}));
+
+		// Act
+		var downloadTasks = blobUrls.Select(url => service.DownloadAsync(url)).ToList();
+		var streams = await Task.WhenAll(downloadTasks);
+
+		// Assert
+		streams.Should().HaveCount(5);
+		streams.Should().AllSatisfy(stream => stream.Should().NotBeNull());
+	}
+
+	[Fact]
+	public async Task UploadAndDownload_Concurrent_ShouldAllComplete()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var seedUrl = await service.UploadAsync(
+			new MemoryStream("Upload and download test"u8.ToArray()),
+			"roundtrip.txt",
+			"text/plain");
+
+		// Act — mixed concurrent uploads and downloads
+		var tasks = new List<Task>();
+
+		for (var i = 0; i < 5; i++)
+		{
+			var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"Upload {i}"));
+			tasks.Add(service.UploadAsync(content, $"parallel-upload-{i}.txt", "text/plain"));
+		}
+
+		for (var i = 0; i < 5; i++)
+		{
+			tasks.Add(service.DownloadAsync(seedUrl));
+		}
+
+		await Task.WhenAll(tasks);
+
+		// Assert
+		tasks.Should().AllSatisfy(task => task.IsCompletedSuccessfully.Should().BeTrue());
+	}
+
+	[Fact]
+	public async Task DeleteAsync_ConcurrentDeletes_ShouldAllSucceed()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+
+		var blobUrls = await Task.WhenAll(Enumerable.Range(0, 5)
+			.Select(i =>
+			{
+				var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"Delete test {i}"));
+				return service.UploadAsync(content, $"delete-concurrent-{i}.txt", "text/plain");
+			}));
+
+		// Act
+		await Task.WhenAll(blobUrls.Select(url => service.DeleteAsync(url)));
+
+		// Assert — every file is gone
+		foreach (var url in blobUrls)
+		{
+			Func<Task> act = async () => await service.DownloadAsync(url);
+			await act.Should().ThrowAsync<FileNotFoundException>();
+		}
+	}
+}

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageDeleteTests.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageDeleteTests.cs
@@ -1,0 +1,99 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GridFsStorageDeleteTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+namespace Persistence.MongoDb.Tests.GridFs.Integration;
+
+/// <summary>
+///   Integration tests for GridFsStorageService delete functionality.
+/// </summary>
+[Collection("GridFsIntegration")]
+public sealed class GridFsStorageDeleteTests
+{
+	private readonly MongoDbGridFsFixture _fixture;
+
+	public GridFsStorageDeleteTests(MongoDbGridFsFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task DeleteAsync_AfterUpload_ShouldRemoveFile()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var blobUrl = await service.UploadAsync(
+			new MemoryStream("Content to be deleted"u8.ToArray()),
+			"delete-test.txt",
+			"text/plain");
+
+		// Act
+		await service.DeleteAsync(blobUrl);
+
+		// Assert — file no longer exists in GridFS
+		Func<Task> act = async () => await service.DownloadAsync(blobUrl);
+		await act.Should().ThrowAsync<FileNotFoundException>();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_WithNonExistentUrl_ShouldNotThrowException()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var nonExistentUrl = "/api/attachments/000000000000000000000001";
+
+		// Act
+		Func<Task> act = async () => await service.DeleteAsync(nonExistentUrl);
+
+		// Assert — deletion of a non-existent file is idempotent
+		await act.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_MultipleTimes_ShouldBeIdempotent()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var blobUrl = await service.UploadAsync(
+			new MemoryStream("Idempotent delete test"u8.ToArray()),
+			"idempotent-delete.txt",
+			"text/plain");
+
+		// Act
+		await service.DeleteAsync(blobUrl);
+		Func<Task> act = async () => await service.DeleteAsync(blobUrl);
+
+		// Assert — second delete should not throw
+		await act.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_ShouldOnlyDeleteSpecifiedFile()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var blobUrl1 = await service.UploadAsync(
+			new MemoryStream("First file"u8.ToArray()),
+			"first.txt",
+			"text/plain");
+		var blobUrl2 = await service.UploadAsync(
+			new MemoryStream("Second file"u8.ToArray()),
+			"second.txt",
+			"text/plain");
+
+		// Act
+		await service.DeleteAsync(blobUrl1);
+
+		// Assert — first file gone, second file still accessible
+		Func<Task> actFirst = async () => await service.DownloadAsync(blobUrl1);
+		await actFirst.Should().ThrowAsync<FileNotFoundException>();
+
+		var secondStream = await service.DownloadAsync(blobUrl2);
+		secondStream.Should().NotBeNull();
+	}
+}

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageDownloadTests.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageDownloadTests.cs
@@ -1,0 +1,98 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GridFsStorageDownloadTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+namespace Persistence.MongoDb.Tests.GridFs.Integration;
+
+/// <summary>
+///   Integration tests for GridFsStorageService download functionality.
+/// </summary>
+[Collection("GridFsIntegration")]
+public sealed class GridFsStorageDownloadTests
+{
+	private readonly MongoDbGridFsFixture _fixture;
+
+	public GridFsStorageDownloadTests(MongoDbGridFsFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task DownloadAsync_AfterUpload_ShouldReturnSameContent()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var originalContent = "This is test content for download verification"u8.ToArray();
+		var blobUrl = await service.UploadAsync(
+			new MemoryStream(originalContent),
+			"download-test.txt",
+			"text/plain");
+
+		// Act
+		var downloadStream = await service.DownloadAsync(blobUrl);
+
+		// Assert
+		using var memoryStream = new MemoryStream();
+		await downloadStream.CopyToAsync(memoryStream);
+		memoryStream.ToArray().Should().Equal(originalContent);
+	}
+
+	[Fact]
+	public async Task DownloadAsync_WithTextContent_ShouldMatchOriginal()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var originalText = "Test text content for roundtrip verification";
+		var blobUrl = await service.UploadAsync(
+			new MemoryStream(System.Text.Encoding.UTF8.GetBytes(originalText)),
+			"text-roundtrip.txt",
+			"text/plain");
+
+		// Act
+		var downloadStream = await service.DownloadAsync(blobUrl);
+
+		// Assert
+		using var reader = new StreamReader(downloadStream);
+		var downloadedText = await reader.ReadToEndAsync();
+		downloadedText.Should().Be(originalText);
+	}
+
+	[Fact]
+	public async Task DownloadAsync_WithNonExistentUrl_ShouldThrowException()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var nonExistentUrl = "/api/attachments/000000000000000000000000";
+
+		// Act
+		Func<Task> act = async () => await service.DownloadAsync(nonExistentUrl);
+
+		// Assert — GridFS throws FileNotFoundException for missing files
+		await act.Should().ThrowAsync<FileNotFoundException>();
+	}
+
+	[Fact]
+	public async Task DownloadAsync_WithBinaryContent_ShouldReturnExactBytes()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var originalBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+		var blobUrl = await service.UploadAsync(
+			new MemoryStream(originalBytes),
+			"binary-test.bin",
+			"application/octet-stream");
+
+		// Act
+		var downloadStream = await service.DownloadAsync(blobUrl);
+
+		// Assert
+		using var memoryStream = new MemoryStream();
+		await downloadStream.CopyToAsync(memoryStream);
+		memoryStream.ToArray().Should().Equal(originalBytes);
+	}
+}

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageThumbnailTests.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageThumbnailTests.cs
@@ -1,0 +1,152 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GridFsStorageThumbnailTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+using SixLabors.ImageSharp.Processing;
+
+namespace Persistence.MongoDb.Tests.GridFs.Integration;
+
+/// <summary>
+///   Integration tests for GridFsStorageService thumbnail generation functionality.
+/// </summary>
+[Collection("GridFsIntegration")]
+public sealed class GridFsStorageThumbnailTests
+{
+	private readonly MongoDbGridFsFixture _fixture;
+
+	public GridFsStorageThumbnailTests(MongoDbGridFsFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_WithValidImage_ShouldReturnThumbnailUrl()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var imageStream = await CreateTestImageAsync(800, 600);
+		var blobUrl = await service.UploadAsync(imageStream, "original.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().NotBeNullOrEmpty();
+		thumbnailUrl.Should().EndWith("/thumbnail");
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_ShouldCreateDownloadableThumbnail()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var imageStream = await CreateTestImageAsync(1024, 768);
+		var blobUrl = await service.UploadAsync(imageStream, "large-image.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert — thumbnail can be downloaded
+		thumbnailUrl.Should().NotBeNull();
+		var downloadStream = await service.DownloadAsync(thumbnailUrl!);
+		downloadStream.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_ShouldResizeImageToMaxDimensions()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var imageStream = await CreateTestImageAsync(800, 600);
+		var blobUrl = await service.UploadAsync(imageStream, "resize-test.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().NotBeNull();
+		var downloadStream = await service.DownloadAsync(thumbnailUrl!);
+		using var thumbnailImage = await Image.LoadAsync(downloadStream);
+
+		thumbnailImage.Width.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_WIDTH);
+		thumbnailImage.Height.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_HEIGHT);
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_WithPortraitImage_ShouldMaintainAspectRatio()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var imageStream = await CreateTestImageAsync(400, 800);
+		var blobUrl = await service.UploadAsync(imageStream, "portrait.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().NotBeNull();
+		var downloadStream = await service.DownloadAsync(thumbnailUrl!);
+		using var thumbnailImage = await Image.LoadAsync(downloadStream);
+
+		thumbnailImage.Width.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_WIDTH);
+		thumbnailImage.Height.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_HEIGHT);
+
+		var expectedRatio = 400.0 / 800.0;
+		var actualRatio = (double)thumbnailImage.Width / thumbnailImage.Height;
+		actualRatio.Should().BeApproximately(expectedRatio, 0.05);
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_WithNonImageFile_ShouldReturnNull()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var textStream = new MemoryStream("Not an image"u8.ToArray());
+		var blobUrl = await service.UploadAsync(textStream, "notimage.txt", "text/plain");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_ShouldSaveAsJpeg()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var imageStream = await CreateTestImageAsync(500, 500);
+		var blobUrl = await service.UploadAsync(imageStream, "format-test.png", "image/png");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert — verify JPEG magic bytes (FF D8 FF)
+		thumbnailUrl.Should().NotBeNull();
+		var downloadStream = await service.DownloadAsync(thumbnailUrl!);
+		using var memoryStream = new MemoryStream();
+		await downloadStream.CopyToAsync(memoryStream);
+		var bytes = memoryStream.ToArray();
+
+		bytes[0].Should().Be(0xFF);
+		bytes[1].Should().Be(0xD8);
+		bytes[2].Should().Be(0xFF);
+	}
+
+	private static async Task<MemoryStream> CreateTestImageAsync(int width, int height)
+	{
+		using var image = new Image<Rgba32>(width, height);
+		image.Mutate(x => x.BackgroundColor(Color.Blue));
+
+		var stream = new MemoryStream();
+		await image.SaveAsJpegAsync(stream);
+		stream.Position = 0;
+		return stream;
+	}
+}

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageUploadTests.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/GridFsStorageUploadTests.cs
@@ -1,0 +1,122 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GridFsStorageUploadTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+namespace Persistence.MongoDb.Tests.GridFs.Integration;
+
+/// <summary>
+///   Integration tests for GridFsStorageService upload functionality.
+/// </summary>
+[Collection("GridFsIntegration")]
+public sealed class GridFsStorageUploadTests
+{
+	private readonly MongoDbGridFsFixture _fixture;
+
+	public GridFsStorageUploadTests(MongoDbGridFsFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithTextFile_ShouldReturnBlobUrl()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var content = new MemoryStream("Test file content"u8.ToArray());
+		var fileName = "test.txt";
+		var contentType = "text/plain";
+
+		// Act
+		var blobUrl = await service.UploadAsync(content, fileName, contentType);
+
+		// Assert
+		blobUrl.Should().NotBeNullOrEmpty();
+		blobUrl.Should().StartWith("/api/attachments/");
+	}
+
+	[Fact]
+	public async Task UploadAsync_ShouldCreateFileInGridFs()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var originalContent = "Test content for verification"u8.ToArray();
+		var content = new MemoryStream(originalContent);
+		var fileName = "verify.txt";
+
+		// Act
+		var blobUrl = await service.UploadAsync(content, fileName, "text/plain");
+
+		// Assert — file can be read back, confirming it exists in GridFS
+		var downloadStream = await service.DownloadAsync(blobUrl);
+		downloadStream.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithSpecificContentType_ShouldStoreContentType()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var content = new MemoryStream("{\"test\":\"json\"}"u8.ToArray());
+		var fileName = "data.json";
+		var contentType = "application/json";
+
+		// Act
+		var blobUrl = await service.UploadAsync(content, fileName, contentType);
+
+		// Assert — GridFS stores contentType in metadata; verify upload and download both succeed
+		blobUrl.Should().NotBeNullOrEmpty();
+		var downloadStream = await service.DownloadAsync(blobUrl);
+		downloadStream.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task UploadAsync_ShouldGenerateUniqueUrls()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var fileName = "duplicate.txt";
+
+		// Act
+		var blobUrl1 = await service.UploadAsync(
+			new MemoryStream("First upload"u8.ToArray()),
+			fileName,
+			"text/plain");
+		var blobUrl2 = await service.UploadAsync(
+			new MemoryStream("Second upload"u8.ToArray()),
+			fileName,
+			"text/plain");
+
+		// Assert
+		blobUrl1.Should().NotBe(blobUrl2);
+		blobUrl1.Should().StartWith("/api/attachments/");
+		blobUrl2.Should().StartWith("/api/attachments/");
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithMultipleFiles_ShouldGenerateUniqueBlobNames()
+	{
+		// Arrange
+		var service = _fixture.CreateGridFsStorageService();
+		var fileName = "multi.txt";
+
+		// Act
+		var uploadTasks = Enumerable.Range(0, 5)
+			.Select(i => service.UploadAsync(
+				new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"Content {i}")),
+				fileName,
+				"text/plain"))
+			.ToList();
+
+		var urls = await Task.WhenAll(uploadTasks);
+
+		// Assert
+		urls.Should().HaveCount(5);
+		urls.Should().OnlyHaveUniqueItems();
+		urls.Should().AllSatisfy(url => url.Should().StartWith("/api/attachments/"));
+	}
+}

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/MongoDbGridFsCollection.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/MongoDbGridFsCollection.cs
@@ -1,0 +1,13 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     MongoDbGridFsCollection.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+namespace Persistence.MongoDb.Tests.GridFs.Integration;
+
+[CollectionDefinition("GridFsIntegration")]
+public sealed class MongoDbGridFsCollection : ICollectionFixture<MongoDbGridFsFixture> { }

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/MongoDbGridFsFixture.cs
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/MongoDbGridFsFixture.cs
@@ -1,0 +1,64 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     MongoDbGridFsFixture.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.MongoDb.Tests.GridFs.Integration
+// =======================================================
+
+namespace Persistence.MongoDb.Tests.GridFs.Integration;
+
+/// <summary>
+///   Shared test fixture using Testcontainers.MongoDb for GridFS integration tests.
+///   Starts a MongoDB container as a single-node replica set.
+/// </summary>
+public sealed class MongoDbGridFsFixture : IAsyncLifetime
+{
+	private MongoDbContainer? _container;
+
+	/// <summary>
+	///   Gets the MongoDB connection string for the test container.
+	/// </summary>
+	public string ConnectionString => _container?.GetConnectionString()
+		?? throw new InvalidOperationException("MongoDB container is not initialized.");
+
+	/// <summary>
+	///   Initializes the MongoDB test container with replica set support.
+	/// </summary>
+	public async Task InitializeAsync()
+	{
+		_container = new MongoDbBuilder("mongo:7.0")
+			.WithReplicaSet("rs0")
+			.Build();
+
+		await _container.StartAsync();
+
+		// Wait for replica set to initialize
+		await Task.Delay(3000);
+	}
+
+	/// <summary>
+	///   Creates a new GridFsStorageService backed by an isolated database.
+	///   Each call returns a fully independent service instance.
+	/// </summary>
+	public GridFsStorageService CreateGridFsStorageService()
+	{
+		var database = new MongoClient(ConnectionString)
+			.GetDatabase($"gridfs-test-{Guid.NewGuid():N}");
+
+		return new GridFsStorageService(database, NullLogger<GridFsStorageService>.Instance);
+	}
+
+	/// <summary>
+	///   Disposes of the MongoDB test container.
+	/// </summary>
+	public async Task DisposeAsync()
+	{
+		if (_container is not null)
+		{
+			await _container.StopAsync();
+			await _container.DisposeAsync();
+		}
+	}
+}

--- a/tests/Persistence.MongoDb.Tests.GridFs.Integration/Persistence.MongoDb.Tests.GridFs.Integration.csproj
+++ b/tests/Persistence.MongoDb.Tests.GridFs.Integration/Persistence.MongoDb.Tests.GridFs.Integration.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="SixLabors.ImageSharp" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Testcontainers.MongoDb" />
+		<PackageReference Include="coverlet.collector">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Persistence.MongoDb\Persistence.MongoDb.csproj" />
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Closes #277

Working as **Gimli** (Tester)

---

### What this PR does

Adds a new `Persistence.MongoDb.Tests.GridFs.Integration` test project with **24 integration tests** that replace Azurite-backed Azure Blob Storage integration coverage with MongoDB GridFS tests using Testcontainers.

### Test coverage (5 classes, 24 tests)

| Class | Tests |
|-------|-------|
| `GridFsStorageUploadTests` | 5 — URL format, file existence, content type, unique URLs, unique blob names |
| `GridFsStorageDownloadTests` | 4 — byte roundtrip, text roundtrip, missing file throws, binary exact match |
| `GridFsStorageDeleteTests` | 4 — removes file, no-throw on missing, idempotent double-delete, only deletes target |
| `GridFsStorageThumbnailTests` | 6 — URL format, downloadable, ≤200×200 resize, aspect ratio, null on non-image, JPEG magic bytes |
| `GridFsStorageConcurrencyTests` | 5 — 10 concurrent uploads (isolated DBs), 10 concurrent uploads (shared DB), 5 concurrent downloads, mixed upload+download, 5 concurrent deletes |

### Implementation notes

- Mirrors the `Persistence.MongoDb.Tests.Integration` pattern exactly (Testcontainers `mongo:7.0` + replica set `rs0` + `Task.Delay(3000)` startup stabiliser)
- Per-test isolation via unique database name (`gridfs-test-{Guid:N}`) — no container restarts needed
- All 24 tests verified locally: **total: 24, failed: 0, succeeded: 24**
- Adds `test-gridfs-integration` CI job to `squad-test.yml` (mirrors `test-persistence-mongodb-integration` structure)