### PR TITLE
feat: port Persistence.AzureStorage + tests from main to dev

### DIFF
--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,6 +1,7 @@
 name: Lint YAML
 # Validates all workflow and config YAML files
 # This workflow emits the required `yamllint` status check on pull requests.
+# Also supports workflow_dispatch for manual triggering on branches without YAML changes.
 
 on:
   push:
@@ -9,6 +10,7 @@ on:
   pull_request:
     branches: [dev, preview, main, insider]
     paths: ['**.yml', '**.yaml']
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,8 @@
     <PackageVersion Include="MongoDB.Bson" Version="3.9.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
     <PackageVersion Include="MongoDB.EntityFrameworkCore" Version="10.0.2" />
+    <!-- Azure Storage -->
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.20.0" />
     <!-- Azure Key Vault -->
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />

--- a/IssueTrackerApp.slnx
+++ b/IssueTrackerApp.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/AppHost/AppHost.csproj" />
     <Project Path="src/Domain/Domain.csproj" />
+    <Project Path="src/Persistence.AzureStorage/Persistence.AzureStorage.csproj" />
     <Project Path="src/Persistence.MongoDb/Persistence.MongoDb.csproj" />
     <Project Path="src/ServiceDefaults/ServiceDefaults.csproj" />
     <Project Path="src/Web/Web.csproj" />
@@ -10,6 +11,8 @@
     <Project Path="tests/AppHost.Tests/AppHost.Tests.csproj" />
     <Project Path="tests/Architecture.Tests/Architecture.Tests.csproj" />
     <Project Path="tests/Domain.Tests/Domain.Tests.csproj" />
+    <Project Path="tests/Persistence.AzureStorage.Tests/Persistence.AzureStorage.Tests.csproj" />
+    <Project Path="tests/Persistence.AzureStorage.Tests.Integration/Persistence.AzureStorage.Tests.Integration.csproj" />
     <Project Path="tests/Persistence.MongoDb.Tests/Persistence.MongoDb.Tests.csproj" />
     <Project Path="tests/Persistence.MongoDb.Tests.Integration/Persistence.MongoDb.Tests.Integration.csproj" />
     <Project Path="tests/Persistence.MongoDb.Tests.GridFs.Integration/Persistence.MongoDb.Tests.GridFs.Integration.csproj" />

--- a/src/Persistence.AzureStorage/BlobStorageService.cs
+++ b/src/Persistence.AzureStorage/BlobStorageService.cs
@@ -1,0 +1,178 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageService.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage
+// =======================================================
+
+namespace Persistence.AzureStorage;
+
+/// <summary>
+///   Implementation of IFileStorageService using Azure Blob Storage.
+/// </summary>
+public class BlobStorageService : IFileStorageService
+{
+	private readonly BlobServiceClient _blobServiceClient;
+	private readonly BlobStorageSettings _settings;
+	private readonly ILogger<BlobStorageService> _logger;
+
+	public BlobStorageService(
+		BlobServiceClient blobServiceClient,
+		IOptions<BlobStorageSettings> settings,
+		ILogger<BlobStorageService> logger)
+	{
+		_blobServiceClient = blobServiceClient ?? throw new ArgumentNullException(nameof(blobServiceClient));
+		_settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+		_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+	}
+
+	public async Task<string> UploadAsync(
+		Stream content,
+		string fileName,
+		string contentType,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			var containerClient = _blobServiceClient.GetBlobContainerClient(_settings.ContainerName);
+			await containerClient.CreateIfNotExistsAsync(
+				PublicAccessType.None,
+				cancellationToken: cancellationToken);
+
+			// Generate unique blob name
+			var blobName = $"{Guid.NewGuid()}/{fileName}";
+			var blobClient = containerClient.GetBlobClient(blobName);
+
+			// Upload with metadata
+			var blobHttpHeaders = new BlobHttpHeaders { ContentType = contentType };
+			await blobClient.UploadAsync(
+				content,
+				new BlobUploadOptions { HttpHeaders = blobHttpHeaders },
+				cancellationToken);
+
+			_logger.LogInformation("Uploaded file {FileName} to blob storage as {BlobName}", fileName, blobName);
+
+			return blobClient.Uri.ToString();
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to upload file {FileName}", fileName);
+			throw;
+		}
+	}
+
+	public async Task<Stream> DownloadAsync(string blobUrl, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			var uri = new Uri(blobUrl);
+			var (containerName, blobName) = ParseBlobUrl(uri);
+			var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+			var blobClient = containerClient.GetBlobClient(blobName);
+			var response = await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken);
+
+			_logger.LogInformation("Downloaded blob from {BlobUrl}", blobUrl);
+
+			return response.Value.Content;
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to download blob from {BlobUrl}", blobUrl);
+			throw;
+		}
+	}
+
+	public async Task DeleteAsync(string blobUrl, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			var uri = new Uri(blobUrl);
+			var (containerName, blobName) = ParseBlobUrl(uri);
+			var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+			var blobClient = containerClient.GetBlobClient(blobName);
+			await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+
+			_logger.LogInformation("Deleted blob at {BlobUrl}", blobUrl);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to delete blob at {BlobUrl}", blobUrl);
+			throw;
+		}
+	}
+
+	/// <summary>
+	///   Parses a blob URL to extract the container name and blob name.
+	/// </summary>
+	/// <param name="blobUri">The blob URI to parse.</param>
+	/// <returns>A tuple containing the container name and blob name.</returns>
+	private static (string containerName, string blobName) ParseBlobUrl(Uri blobUri)
+	{
+		// URL format: https://{account}.blob.core.windows.net/{container}/{blobname}
+		// Or for Azurite: http://127.0.0.1:10000/{account}/{container}/{blobname}
+		var segments = blobUri.AbsolutePath.TrimStart('/').Split('/', 2);
+
+		if (segments.Length < 2)
+		{
+			throw new ArgumentException($"Invalid blob URL format: {blobUri}", nameof(blobUri));
+		}
+
+		// For Azurite, first segment is the account name, so we need to skip it
+		if (blobUri.Host.Contains("127.0.0.1") || blobUri.Host.Contains("localhost"))
+		{
+			segments = segments[1].Split('/', 2);
+		}
+
+		return (containerName: segments[0], blobName: segments[1]);
+	}
+
+	public async Task<string?> GenerateThumbnailAsync(
+		string blobUrl,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			// Download original image
+			var originalStream = await DownloadAsync(blobUrl, cancellationToken);
+
+			// Generate thumbnail using ImageSharp
+			using var image = await Image.LoadAsync(originalStream, cancellationToken);
+			using var thumbnailStream = new MemoryStream();
+
+			image.Mutate(x => x.Resize(new ResizeOptions
+			{
+				Size = new Size(FileValidationConstants.THUMBNAIL_WIDTH, FileValidationConstants.THUMBNAIL_HEIGHT),
+				Mode = ResizeMode.Max
+			}));
+
+			await image.SaveAsJpegAsync(thumbnailStream, cancellationToken);
+			thumbnailStream.Position = 0;
+
+			// Upload thumbnail
+			var containerClient = _blobServiceClient.GetBlobContainerClient(_settings.ThumbnailContainerName);
+			await containerClient.CreateIfNotExistsAsync(
+				PublicAccessType.None,
+				cancellationToken: cancellationToken);
+
+			var blobName = $"{Guid.NewGuid()}/thumbnail.jpg";
+			var blobClient = containerClient.GetBlobClient(blobName);
+
+			var blobHttpHeaders = new BlobHttpHeaders { ContentType = "image/jpeg" };
+			await blobClient.UploadAsync(
+				thumbnailStream,
+				new BlobUploadOptions { HttpHeaders = blobHttpHeaders },
+				cancellationToken);
+
+			_logger.LogInformation("Generated thumbnail for {BlobUrl}", blobUrl);
+
+			return blobClient.Uri.ToString();
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to generate thumbnail for {BlobUrl}", blobUrl);
+			return null;
+		}
+	}
+}

--- a/src/Persistence.AzureStorage/BlobStorageSettings.cs
+++ b/src/Persistence.AzureStorage/BlobStorageSettings.cs
@@ -1,0 +1,33 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageSettings.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage
+// =======================================================
+
+namespace Persistence.AzureStorage;
+
+/// <summary>
+///   Configuration settings for Azure Blob Storage.
+/// </summary>
+public class BlobStorageSettings
+{
+	public const string SECTION_NAME = "BlobStorage";
+
+	/// <summary>
+	///   Gets or sets the Azure Blob Storage connection string.
+	/// </summary>
+	public string ConnectionString { get; set; } = string.Empty;
+
+	/// <summary>
+	///   Gets or sets the container name for issue attachments.
+	/// </summary>
+	public string ContainerName { get; set; } = "issue-attachments";
+
+	/// <summary>
+	///   Gets or sets the container name for thumbnails.
+	/// </summary>
+	public string ThumbnailContainerName { get; set; } = "issue-attachments-thumbnails";
+}

--- a/src/Persistence.AzureStorage/GlobalUsings.cs
+++ b/src/Persistence.AzureStorage/GlobalUsings.cs
@@ -1,0 +1,25 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GlobalUsings.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage
+// =======================================================
+
+global using System;
+global using System.IO;
+global using System.Threading;
+global using System.Threading.Tasks;
+
+global using Azure.Storage.Blobs;
+global using Azure.Storage.Blobs.Models;
+
+global using Domain.Abstractions;
+global using Domain.Models;
+
+global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Options;
+
+global using SixLabors.ImageSharp;
+global using SixLabors.ImageSharp.Processing;

--- a/src/Persistence.AzureStorage/Persistence.AzureStorage.csproj
+++ b/src/Persistence.AzureStorage/Persistence.AzureStorage.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Domain\Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Persistence.AzureStorage/ServiceCollectionExtensions.cs
+++ b/src/Persistence.AzureStorage/ServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     ServiceCollectionExtensions.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage
+// =======================================================
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Persistence.AzureStorage;
+
+/// <summary>
+///   Extension methods for registering Azure Storage services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+	/// <summary>
+	///   Adds Azure Blob Storage services to the service collection.
+	/// </summary>
+	public static IServiceCollection AddAzureBlobStorage(
+		this IServiceCollection services,
+		IConfiguration configuration)
+	{
+		// Configure settings
+		services.Configure<BlobStorageSettings>(
+			configuration.GetSection(BlobStorageSettings.SECTION_NAME));
+
+		// Register BlobServiceClient
+		var connectionString = configuration[$"{BlobStorageSettings.SECTION_NAME}:ConnectionString"];
+
+		if (!string.IsNullOrEmpty(connectionString))
+		{
+			services.AddSingleton(new BlobServiceClient(connectionString));
+			services.AddScoped<IFileStorageService, BlobStorageService>();
+		}
+
+		return services;
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/AzuriteCollection.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/AzuriteCollection.cs
@@ -1,0 +1,18 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     AzuriteCollection.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests.Integration;
+
+/// <summary>
+///   xUnit collection definition for tests using the Azurite fixture.
+/// </summary>
+[CollectionDefinition("Azurite")]
+public class AzuriteCollection : ICollectionFixture<AzuriteFixture>
+{
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/AzuriteFixture.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/AzuriteFixture.cs
@@ -1,0 +1,49 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     AzuriteFixture.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests.Integration;
+
+/// <summary>
+///   xUnit fixture that starts an Azurite Docker container for integration tests.
+/// </summary>
+public sealed class AzuriteFixture : IAsyncLifetime
+{
+	private readonly AzuriteContainer _container;
+
+	public AzuriteFixture()
+	{
+		_container = new AzuriteBuilder("mcr.microsoft.com/azure-storage/azurite:latest")
+			.Build();
+	}
+
+	public string ConnectionString => _container.GetConnectionString();
+
+	public BlobServiceClient CreateBlobServiceClient() => new(ConnectionString);
+
+	public BlobStorageService CreateBlobStorageService(
+		string containerName = "issue-attachments",
+		string thumbnailContainerName = "issue-attachments-thumbnails")
+	{
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ConnectionString = ConnectionString,
+			ContainerName = containerName,
+			ThumbnailContainerName = thumbnailContainerName
+		});
+
+		return new BlobStorageService(
+			CreateBlobServiceClient(),
+			settings,
+			NullLogger<BlobStorageService>.Instance);
+	}
+
+	public async Task InitializeAsync() => await _container.StartAsync();
+
+	public async Task DisposeAsync() => await _container.DisposeAsync();
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageConcurrencyTests.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageConcurrencyTests.cs
@@ -1,0 +1,208 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageConcurrencyTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests.Integration;
+
+/// <summary>
+///   Integration tests for BlobStorageService concurrent operations.
+/// </summary>
+[Collection("Azurite")]
+public sealed class BlobStorageConcurrencyTests
+{
+	private readonly AzuriteFixture _fixture;
+
+	public BlobStorageConcurrencyTests(AzuriteFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithMultipleConcurrentUploads_ShouldAllSucceed()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var uploadTasks = new List<Task<string>>();
+
+		// Act
+		for (int i = 0; i < 10; i++)
+		{
+			var contentText = $"Concurrent upload {i}";
+			var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(contentText));
+			var fileName = $"concurrent-{i}.txt";
+			uploadTasks.Add(service.UploadAsync(content, fileName, "text/plain"));
+		}
+
+		var blobUrls = await Task.WhenAll(uploadTasks);
+
+		// Assert
+		blobUrls.Should().HaveCount(10);
+		blobUrls.Should().OnlyHaveUniqueItems();
+		blobUrls.Should().AllSatisfy(url => url.Should().NotBeNullOrEmpty());
+	}
+
+	[Fact]
+	public async Task UploadAsync_ConcurrentUploadsToSameContainer_ShouldAllSucceed()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+
+		// Act
+		var uploadTasks = Enumerable.Range(0, 10)
+			.Select(i =>
+			{
+				var contentText = $"Container test {i}";
+				var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(contentText));
+				return service.UploadAsync(content, $"same-container-{i}.txt", "text/plain");
+			})
+			.ToList();
+
+		var blobUrls = await Task.WhenAll(uploadTasks);
+
+		// Assert
+		blobUrls.Should().HaveCount(10);
+		blobUrls.Should().OnlyHaveUniqueItems();
+
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+		var exists = await containerClient.ExistsAsync();
+		exists.Value.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task DownloadAsync_ConcurrentDownloads_ShouldAllSucceed()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+
+		var uploadTasks = Enumerable.Range(0, 5)
+			.Select(i =>
+			{
+				var contentText = $"Download test {i}";
+				var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(contentText));
+				return service.UploadAsync(content, $"download-{i}.txt", "text/plain");
+			})
+			.ToList();
+
+		var blobUrls = await Task.WhenAll(uploadTasks);
+
+		// Act
+		var downloadTasks = blobUrls.Select(url => service.DownloadAsync(url)).ToList();
+		var streams = await Task.WhenAll(downloadTasks);
+
+		// Assert
+		streams.Should().HaveCount(5);
+		streams.Should().AllSatisfy(stream => stream.Should().NotBeNull());
+	}
+
+	[Fact]
+	public async Task UploadAndDownload_Concurrent_ShouldAllComplete()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+
+		var uploadContent = new MemoryStream("Upload and download test"u8.ToArray());
+		var blobUrl = await service.UploadAsync(uploadContent, "roundtrip.txt", "text/plain");
+
+		// Act
+		var tasks = new List<Task>();
+
+		for (int i = 0; i < 5; i++)
+		{
+			var contentText = $"Upload {i}";
+			var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(contentText));
+			tasks.Add(service.UploadAsync(content, $"parallel-upload-{i}.txt", "text/plain"));
+		}
+
+		for (int i = 0; i < 5; i++)
+		{
+			tasks.Add(service.DownloadAsync(blobUrl));
+		}
+
+		await Task.WhenAll(tasks);
+
+		// Assert
+		tasks.Should().AllSatisfy(task => task.IsCompletedSuccessfully.Should().BeTrue());
+	}
+
+	[Fact]
+	public async Task DeleteAsync_ConcurrentDeletes_ShouldAllSucceed()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+
+		var uploadTasks = Enumerable.Range(0, 5)
+			.Select(i =>
+			{
+				var contentText = $"Delete test {i}";
+				var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(contentText));
+				return service.UploadAsync(content, $"delete-concurrent-{i}.txt", "text/plain");
+			})
+			.ToList();
+
+		var blobUrls = await Task.WhenAll(uploadTasks);
+
+		// Act
+		var deleteTasks = blobUrls.Select(url => service.DeleteAsync(url)).ToList();
+		await Task.WhenAll(deleteTasks);
+
+		// Assert - Azurite format: http://host/account/container/guid/filename
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+
+		foreach (var blobUrl in blobUrls)
+		{
+			var uri = new Uri(blobUrl);
+			var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+			var blobName = string.Join("/", segments.Skip(2)); // Skip account + container
+
+			var blobClient = containerClient.GetBlobClient(blobName);
+			var exists = await blobClient.ExistsAsync();
+			exists.Value.Should().BeFalse();
+		}
+	}
+
+	[Fact]
+	public async Task ConcurrentOperations_MixedTypes_ShouldAllComplete()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+
+		var uploadContent = new MemoryStream("Setup blob"u8.ToArray());
+		var setupBlobUrl = await service.UploadAsync(uploadContent, "setup.txt", "text/plain");
+
+		// Act
+		var tasks = new List<Task>();
+
+		tasks.Add(service.UploadAsync(
+			new MemoryStream("Upload 1"u8.ToArray()),
+			"mixed-1.txt",
+			"text/plain"));
+		tasks.Add(service.DownloadAsync(setupBlobUrl));
+		tasks.Add(service.UploadAsync(
+			new MemoryStream("Upload 2"u8.ToArray()),
+			"mixed-2.txt",
+			"text/plain"));
+		tasks.Add(service.DownloadAsync(setupBlobUrl));
+		tasks.Add(service.UploadAsync(
+			new MemoryStream("Upload 3"u8.ToArray()),
+			"mixed-3.txt",
+			"text/plain"));
+
+		await Task.WhenAll(tasks);
+
+		// Assert
+		tasks.Should().AllSatisfy(task => task.IsCompletedSuccessfully.Should().BeTrue());
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageDeleteTests.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageDeleteTests.cs
@@ -1,0 +1,119 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageDeleteTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests.Integration;
+
+/// <summary>
+///   Integration tests for BlobStorageService delete functionality.
+/// </summary>
+[Collection("Azurite")]
+public sealed class BlobStorageDeleteTests
+{
+	private readonly AzuriteFixture _fixture;
+
+	public BlobStorageDeleteTests(AzuriteFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task DeleteAsync_AfterUpload_ShouldRemoveBlob()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var content = new MemoryStream("Content to be deleted"u8.ToArray());
+		var fileName = "delete-test.txt";
+
+		var blobUrl = await service.UploadAsync(content, fileName, "text/plain");
+
+		// Act
+		await service.DeleteAsync(blobUrl);
+
+		// Assert - use authenticated client from fixture
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+		var blobClient = containerClient.GetBlobClient(fileName);
+		var exists = await blobClient.ExistsAsync();
+		exists.Value.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_WithNonExistentBlob_ShouldNotThrowException()
+	{
+		// Arrange
+		var service = _fixture.CreateBlobStorageService();
+		var nonExistentUrl = "http://127.0.0.1:10000/devstoreaccount1/test-container/nonexistent-blob.txt";
+
+		// Act
+		Func<Task> act = async () => await service.DeleteAsync(nonExistentUrl);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_MultipleTimes_ShouldBeIdempotent()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var content = new MemoryStream("Idempotent delete test"u8.ToArray());
+		var fileName = "idempotent-delete.txt";
+
+		var blobUrl = await service.UploadAsync(content, fileName, "text/plain");
+
+		// Act
+		await service.DeleteAsync(blobUrl);
+		Func<Task> act = async () => await service.DeleteAsync(blobUrl);
+
+		// Assert
+		await act.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_ShouldOnlyDeleteSpecifiedBlob()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+
+		var blobUrl1 = await service.UploadAsync(
+			new MemoryStream("First blob"u8.ToArray()),
+			"first.txt",
+			"text/plain");
+		var blobUrl2 = await service.UploadAsync(
+			new MemoryStream("Second blob"u8.ToArray()),
+			"second.txt",
+			"text/plain");
+
+		// Act
+		await service.DeleteAsync(blobUrl1);
+
+		// Assert - Azurite format: http://host/account/container/guid/filename
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+
+		// Extract blob1 name from URL
+		var uri1 = new Uri(blobUrl1);
+		var segments1 = uri1.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+		var blobName1 = string.Join("/", segments1.Skip(2)); // Skip account + container
+		var blobClient1 = containerClient.GetBlobClient(blobName1);
+		var exists1 = await blobClient1.ExistsAsync();
+		exists1.Value.Should().BeFalse();
+
+		// Extract blob2 name from URL
+		var uri2 = new Uri(blobUrl2);
+		var segments2 = uri2.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+		var blobName2 = string.Join("/", segments2.Skip(2)); // Skip account + container
+		var blobClient2 = containerClient.GetBlobClient(blobName2);
+		var exists2 = await blobClient2.ExistsAsync();
+		exists2.Value.Should().BeTrue();
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageDownloadTests.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageDownloadTests.cs
@@ -1,0 +1,103 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageDownloadTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests.Integration;
+
+/// <summary>
+///   Integration tests for BlobStorageService download functionality.
+/// </summary>
+[Collection("Azurite")]
+public sealed class BlobStorageDownloadTests
+{
+	private readonly AzuriteFixture _fixture;
+
+	public BlobStorageDownloadTests(AzuriteFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task DownloadAsync_AfterUpload_ShouldReturnSameContent()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var originalContent = "This is test content for download verification"u8.ToArray();
+		var uploadStream = new MemoryStream(originalContent);
+		var fileName = "download-test.txt";
+
+		var blobUrl = await service.UploadAsync(uploadStream, fileName, "text/plain");
+
+		// Act
+		var downloadStream = await service.DownloadAsync(blobUrl);
+
+		// Assert
+		using var memoryStream = new MemoryStream();
+		await downloadStream.CopyToAsync(memoryStream);
+		var downloadedContent = memoryStream.ToArray();
+		downloadedContent.Should().Equal(originalContent);
+	}
+
+	[Fact]
+	public async Task DownloadAsync_WithTextContent_ShouldMatchOriginal()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var originalText = "Test text content for roundtrip verification";
+		var uploadStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(originalText));
+		var fileName = "text-roundtrip.txt";
+
+		var blobUrl = await service.UploadAsync(uploadStream, fileName, "text/plain");
+
+		// Act
+		var downloadStream = await service.DownloadAsync(blobUrl);
+
+		// Assert
+		using var reader = new StreamReader(downloadStream);
+		var downloadedText = await reader.ReadToEndAsync();
+		downloadedText.Should().Be(originalText);
+	}
+
+	[Fact]
+	public async Task DownloadAsync_WithNonExistentBlob_ShouldThrowException()
+	{
+		// Arrange
+		var service = _fixture.CreateBlobStorageService();
+		var nonExistentUrl = "http://127.0.0.1:10000/devstoreaccount1/nonexistent/blob.txt";
+
+		// Act
+		Func<Task> act = async () => await service.DownloadAsync(nonExistentUrl);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Fact]
+	public async Task DownloadAsync_WithBinaryContent_ShouldReturnExactBytes()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var originalBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+		var uploadStream = new MemoryStream(originalBytes);
+		var fileName = "binary-test.bin";
+
+		var blobUrl = await service.UploadAsync(uploadStream, fileName, "application/octet-stream");
+
+		// Act
+		var downloadStream = await service.DownloadAsync(blobUrl);
+
+		// Assert
+		using var memoryStream = new MemoryStream();
+		await downloadStream.CopyToAsync(memoryStream);
+		var downloadedBytes = memoryStream.ToArray();
+		downloadedBytes.Should().Equal(originalBytes);
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageThumbnailTests.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageThumbnailTests.cs
@@ -1,0 +1,182 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageThumbnailTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace Persistence.AzureStorage.Tests.Integration;
+
+/// <summary>
+///   Integration tests for BlobStorageService thumbnail generation functionality.
+/// </summary>
+[Collection("Azurite")]
+public sealed class BlobStorageThumbnailTests
+{
+	private readonly AzuriteFixture _fixture;
+
+	public BlobStorageThumbnailTests(AzuriteFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_WithValidImage_ShouldReturnThumbnailUrl()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var thumbnailContainerName = $"test-thumb-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName, thumbnailContainerName);
+
+		var imageStream = await CreateTestImageAsync(800, 600);
+		var blobUrl = await service.UploadAsync(imageStream, "original.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().NotBeNullOrEmpty();
+		thumbnailUrl.Should().Contain(thumbnailContainerName);
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_ShouldCreateThumbnailBlob()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var thumbnailContainerName = $"test-thumb-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName, thumbnailContainerName);
+
+		var imageStream = await CreateTestImageAsync(1024, 768);
+		var blobUrl = await service.UploadAsync(imageStream, "large-image.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert - Azurite format: http://host/account/container/guid/filename
+		thumbnailUrl.Should().NotBeNull();
+
+		var uri = new Uri(thumbnailUrl!);
+		var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+		var blobName = string.Join("/", segments.Skip(2)); // Skip account + container
+
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(thumbnailContainerName);
+		var blobClient = containerClient.GetBlobClient(blobName);
+		var exists = await blobClient.ExistsAsync();
+		exists.Value.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_ShouldResizeImageToMaxDimensions()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var thumbnailContainerName = $"test-thumb-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName, thumbnailContainerName);
+
+		var imageStream = await CreateTestImageAsync(800, 600);
+		var blobUrl = await service.UploadAsync(imageStream, "resize-test.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().NotBeNull();
+		var downloadStream = await service.DownloadAsync(thumbnailUrl!);
+		using var thumbnailImage = await Image.LoadAsync(downloadStream);
+
+		thumbnailImage.Width.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_WIDTH);
+		thumbnailImage.Height.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_HEIGHT);
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_WithPortraitImage_ShouldMaintainAspectRatio()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var thumbnailContainerName = $"test-thumb-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName, thumbnailContainerName);
+
+		var imageStream = await CreateTestImageAsync(400, 800);
+		var blobUrl = await service.UploadAsync(imageStream, "portrait.jpg", "image/jpeg");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().NotBeNull();
+		var downloadStream = await service.DownloadAsync(thumbnailUrl!);
+		using var thumbnailImage = await Image.LoadAsync(downloadStream);
+
+		thumbnailImage.Width.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_WIDTH);
+		thumbnailImage.Height.Should().BeLessThanOrEqualTo(FileValidationConstants.THUMBNAIL_HEIGHT);
+
+		var expectedRatio = 400.0 / 800.0;
+		var actualRatio = (double)thumbnailImage.Width / thumbnailImage.Height;
+		actualRatio.Should().BeApproximately(expectedRatio, 0.01);
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_WithNonImageFile_ShouldReturnNull()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var thumbnailContainerName = $"test-thumb-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName, thumbnailContainerName);
+
+		var textStream = new MemoryStream("Not an image"u8.ToArray());
+		var blobUrl = await service.UploadAsync(textStream, "notimage.txt", "text/plain");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		thumbnailUrl.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_ShouldSaveAsJpeg()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var thumbnailContainerName = $"test-thumb-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName, thumbnailContainerName);
+
+		var imageStream = await CreateTestImageAsync(500, 500);
+		var blobUrl = await service.UploadAsync(imageStream, "format-test.png", "image/png");
+
+		// Act
+		var thumbnailUrl = await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert - Azurite format: http://host/account/container/guid/filename
+		thumbnailUrl.Should().NotBeNull();
+
+		var uri = new Uri(thumbnailUrl!);
+		var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+		var blobName = string.Join("/", segments.Skip(2)); // Skip account + container
+
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(thumbnailContainerName);
+		var blobClient = containerClient.GetBlobClient(blobName);
+		var properties = await blobClient.GetPropertiesAsync();
+		properties.Value.ContentType.Should().Be("image/jpeg");
+	}
+
+	private static async Task<MemoryStream> CreateTestImageAsync(int width, int height)
+	{
+		using var image = new Image<Rgba32>(width, height);
+		image.Mutate(x => x.BackgroundColor(Color.Blue));
+
+		var stream = new MemoryStream();
+		await image.SaveAsJpegAsync(stream);
+		stream.Position = 0;
+		return stream;
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageUploadTests.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/BlobStorageUploadTests.cs
@@ -1,0 +1,141 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageUploadTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests.Integration;
+
+/// <summary>
+///   Integration tests for BlobStorageService upload functionality.
+/// </summary>
+[Collection("Azurite")]
+public sealed class BlobStorageUploadTests
+{
+	private readonly AzuriteFixture _fixture;
+
+	public BlobStorageUploadTests(AzuriteFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithTextFile_ShouldReturnBlobUrl()
+	{
+		// Arrange
+		var service = _fixture.CreateBlobStorageService();
+		var content = new MemoryStream("Test file content"u8.ToArray());
+		var fileName = "test.txt";
+		var contentType = "text/plain";
+
+		// Act
+		var blobUrl = await service.UploadAsync(content, fileName, contentType);
+
+		// Assert
+		blobUrl.Should().NotBeNullOrEmpty();
+		blobUrl.Should().Contain(fileName);
+	}
+
+	[Fact]
+	public async Task UploadAsync_ShouldCreateBlobInContainer()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var content = new MemoryStream("Test content for verification"u8.ToArray());
+		var fileName = "verify.txt";
+		var contentType = "text/plain";
+
+		// Act
+		var blobUrl = await service.UploadAsync(content, fileName, contentType);
+
+		// Assert - use authenticated client from fixture
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+		var exists = await containerClient.ExistsAsync();
+		exists.Value.Should().BeTrue();
+
+		// Extract blob name from URL - Azurite format: http://host/account/container/guid/filename
+		// Skip account name and container name to get blob path
+		var uri = new Uri(blobUrl);
+		var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+		var blobName = string.Join("/", segments.Skip(2)); // Skip account + container
+
+		var blobClient = containerClient.GetBlobClient(blobName);
+		var blobExists = await blobClient.ExistsAsync();
+		blobExists.Value.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithSpecificContentType_ShouldSetCorrectContentType()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var content = new MemoryStream("{\"test\":\"json\"}"u8.ToArray());
+		var fileName = "data.json";
+		var contentType = "application/json";
+
+		// Act
+		var blobUrl = await service.UploadAsync(content, fileName, contentType);
+
+		// Assert - Azurite format: http://host/account/container/guid/filename
+		var uri = new Uri(blobUrl);
+		var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+		var blobName = string.Join("/", segments.Skip(2)); // Skip account + container
+
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+		var blobClient = containerClient.GetBlobClient(blobName);
+		var properties = await blobClient.GetPropertiesAsync();
+		properties.Value.ContentType.Should().Be(contentType);
+	}
+
+	[Fact]
+	public async Task UploadAsync_ShouldCreateContainerAutomatically()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var content = new MemoryStream("Auto-create container test"u8.ToArray());
+		var fileName = "autotest.txt";
+		var contentType = "text/plain";
+
+		// Act
+		var blobUrl = await service.UploadAsync(content, fileName, contentType);
+
+		// Assert
+		var blobServiceClient = _fixture.CreateBlobServiceClient();
+		var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+		var exists = await containerClient.ExistsAsync();
+		exists.Value.Should().BeTrue();
+		blobUrl.Should().Contain(containerName);
+	}
+
+	[Fact]
+	public async Task UploadAsync_WithMultipleFiles_ShouldGenerateUniqueBlobNames()
+	{
+		// Arrange
+		var containerName = $"test-{Guid.NewGuid():N}";
+		var service = _fixture.CreateBlobStorageService(containerName: containerName);
+		var fileName = "duplicate.txt";
+
+		// Act
+		var blobUrl1 = await service.UploadAsync(
+			new MemoryStream("First upload"u8.ToArray()),
+			fileName,
+			"text/plain");
+		var blobUrl2 = await service.UploadAsync(
+			new MemoryStream("Second upload"u8.ToArray()),
+			fileName,
+			"text/plain");
+
+		// Assert
+		blobUrl1.Should().NotBe(blobUrl2);
+		blobUrl1.Should().Contain(fileName);
+		blobUrl2.Should().Contain(fileName);
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests.Integration/GlobalUsings.cs
+++ b/tests/Persistence.AzureStorage.Tests.Integration/GlobalUsings.cs
@@ -1,0 +1,33 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GlobalUsings.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests.Integration
+// =======================================================
+
+// Testing
+// System
+global using System;
+global using System.IO;
+global using System.Threading;
+global using System.Threading.Tasks;
+// Azure Storage
+global using Azure.Storage.Blobs;
+global using Azure.Storage.Blobs.Models;
+// Domain
+global using Domain.Abstractions;
+global using Domain.Models;
+
+global using FluentAssertions;
+// Microsoft Extensions
+global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Logging.Abstractions;
+global using Microsoft.Extensions.Options;
+// Project Under Test
+global using Persistence.AzureStorage;
+// Testcontainers
+global using Testcontainers.Azurite;
+
+global using Xunit;

--- a/tests/Persistence.AzureStorage.Tests.Integration/Persistence.AzureStorage.Tests.Integration.csproj
+++ b/tests/Persistence.AzureStorage.Tests.Integration/Persistence.AzureStorage.Tests.Integration.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="Azure.Storage.Blobs" />
+		<PackageReference Include="SixLabors.ImageSharp" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Options" />
+		<PackageReference Include="Testcontainers.Azurite" />
+		<PackageReference Include="coverlet.collector">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Persistence.AzureStorage\Persistence.AzureStorage.csproj" />
+	</ItemGroup>
+</Project>

--- a/tests/Persistence.AzureStorage.Tests/BlobStorageServiceConstructorTests.cs
+++ b/tests/Persistence.AzureStorage.Tests/BlobStorageServiceConstructorTests.cs
@@ -1,0 +1,85 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageServiceConstructorTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests;
+
+/// <summary>
+///   Unit tests for BlobStorageService constructor validation.
+/// </summary>
+public sealed class BlobStorageServiceConstructorTests
+{
+	[Fact]
+	public void Constructor_WhenBlobServiceClientIsNull_ShouldThrowArgumentNullException()
+	{
+		// Arrange
+		BlobServiceClient? blobServiceClient = null;
+		var settings = Options.Create(new BlobStorageSettings());
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+
+		// Act
+		Action act = () => new BlobStorageService(blobServiceClient!, settings, logger);
+
+		// Assert
+		act.Should().Throw<ArgumentNullException>()
+			.WithParameterName(nameof(blobServiceClient));
+	}
+
+	[Fact]
+	public void Constructor_WhenSettingsIsNull_ShouldThrowArgumentNullException()
+	{
+		// Arrange
+		var blobServiceClient = Substitute.For<BlobServiceClient>();
+		IOptions<BlobStorageSettings>? settings = null;
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+
+		// Act
+		Action act = () => new BlobStorageService(blobServiceClient, settings!, logger);
+
+		// Assert
+		act.Should().Throw<ArgumentNullException>()
+			.WithParameterName("settings");
+	}
+
+	[Fact]
+	public void Constructor_WhenLoggerIsNull_ShouldThrowArgumentNullException()
+	{
+		// Arrange
+		var blobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings());
+		ILogger<BlobStorageService>? logger = null;
+
+		// Act
+		Action act = () => new BlobStorageService(blobServiceClient, settings, logger!);
+
+		// Assert
+		act.Should().Throw<ArgumentNullException>()
+			.WithParameterName(nameof(logger));
+	}
+
+	[Fact]
+	public void Constructor_WhenAllDependenciesAreValid_ShouldCreateInstance()
+	{
+		// Arrange
+		var blobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ConnectionString = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==",
+			ContainerName = "test-container",
+			ThumbnailContainerName = "test-thumbnails"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+
+		// Act
+		var service = new BlobStorageService(blobServiceClient, settings, logger);
+
+		// Assert
+		service.Should().NotBeNull();
+		service.Should().BeAssignableTo<IFileStorageService>();
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests/BlobStorageServiceDeleteTests.cs
+++ b/tests/Persistence.AzureStorage.Tests/BlobStorageServiceDeleteTests.cs
@@ -1,0 +1,100 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageServiceDeleteTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests;
+
+/// <summary>
+///   Unit tests for BlobStorageService delete operations.
+///   Note: DeleteAsync creates BlobClient directly from URI, so we primarily test exception handling.
+/// </summary>
+public sealed class BlobStorageServiceDeleteTests
+{
+	[Fact]
+	public async Task DeleteAsync_WhenExceptionOccurs_ShouldLogError()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		// Invalid URL will cause exception when creating BlobClient
+		var invalidBlobUrl = "not-a-valid-url";
+
+		// Act
+		Func<Task> act = async () => await service.DeleteAsync(invalidBlobUrl);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+
+		logger.Received(1).Log(
+			LogLevel.Error,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(invalidBlobUrl)),
+			Arg.Any<Exception>(),
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+
+	[Fact]
+	public async Task DeleteAsync_WhenExceptionOccurs_ShouldRethrowException()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		var invalidBlobUrl = "not-a-valid-url";
+
+		// Act
+		Func<Task> act = async () => await service.DeleteAsync(invalidBlobUrl);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Fact]
+	public async Task DeleteAsync_ShouldIncludeBlobUrlInLogging()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		var blobUrl = "invalid-url-for-test";
+
+		// Act
+		try
+		{
+			await service.DeleteAsync(blobUrl);
+		}
+		catch
+		{
+			// Expected to fail
+		}
+
+		// Assert
+		logger.Received(1).Log(
+			LogLevel.Error,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(blobUrl)),
+			Arg.Any<Exception>(),
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests/BlobStorageServiceDownloadTests.cs
+++ b/tests/Persistence.AzureStorage.Tests/BlobStorageServiceDownloadTests.cs
@@ -1,0 +1,100 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageServiceDownloadTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests;
+
+/// <summary>
+///   Unit tests for BlobStorageService download operations.
+///   Note: DownloadAsync creates BlobClient directly from URI, so we primarily test exception handling.
+/// </summary>
+public sealed class BlobStorageServiceDownloadTests
+{
+	[Fact]
+	public async Task DownloadAsync_WhenExceptionOccurs_ShouldLogError()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		// Invalid URL will cause exception when creating BlobClient
+		var invalidBlobUrl = "not-a-valid-url";
+
+		// Act
+		Func<Task> act = async () => await service.DownloadAsync(invalidBlobUrl);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+
+		logger.Received(1).Log(
+			LogLevel.Error,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(invalidBlobUrl)),
+			Arg.Any<Exception>(),
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+
+	[Fact]
+	public async Task DownloadAsync_WhenExceptionOccurs_ShouldRethrowException()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		var invalidBlobUrl = "not-a-valid-url";
+
+		// Act
+		Func<Task> act = async () => await service.DownloadAsync(invalidBlobUrl);
+
+		// Assert
+		await act.Should().ThrowAsync<Exception>();
+	}
+
+	[Fact]
+	public async Task DownloadAsync_ShouldIncludeBlobUrlInLogging()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		var blobUrl = "invalid-url-for-test";
+
+		// Act
+		try
+		{
+			await service.DownloadAsync(blobUrl);
+		}
+		catch
+		{
+			// Expected to fail
+		}
+
+		// Assert
+		logger.Received(1).Log(
+			LogLevel.Error,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(blobUrl)),
+			Arg.Any<Exception>(),
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests/BlobStorageServiceThumbnailTests.cs
+++ b/tests/Persistence.AzureStorage.Tests/BlobStorageServiceThumbnailTests.cs
@@ -1,0 +1,99 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageServiceThumbnailTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests;
+
+/// <summary>
+///   Unit tests for BlobStorageService thumbnail generation.
+///   Note: GenerateThumbnailAsync depends on DownloadAsync which creates BlobClient directly,
+///   so we primarily test exception handling and null return on error.
+/// </summary>
+public sealed class BlobStorageServiceThumbnailTests
+{
+	[Fact]
+	public async Task GenerateThumbnailAsync_WhenExceptionOccurs_ShouldReturnNull()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container",
+			ThumbnailContainerName = "test-thumbnails"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		// Invalid URL will cause exception in DownloadAsync
+		var invalidBlobUrl = "not-a-valid-url";
+
+		// Act
+		var result = await service.GenerateThumbnailAsync(invalidBlobUrl);
+
+		// Assert
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_WhenExceptionOccurs_ShouldLogError()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container",
+			ThumbnailContainerName = "test-thumbnails"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		var invalidBlobUrl = "not-a-valid-url";
+
+		// Act
+		await service.GenerateThumbnailAsync(invalidBlobUrl);
+
+		// Assert
+		// GenerateThumbnailAsync calls DownloadAsync which logs, then logs itself
+		// So we expect 2 error log calls
+		logger.Received(2).Log(
+			LogLevel.Error,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(invalidBlobUrl)),
+			Arg.Any<Exception>(),
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+
+	[Fact]
+	public async Task GenerateThumbnailAsync_ShouldIncludeBlobUrlInLogging()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container",
+			ThumbnailContainerName = "test-thumbnails"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		var blobUrl = "invalid-url-for-test";
+
+		// Act
+		await service.GenerateThumbnailAsync(blobUrl);
+
+		// Assert
+		// GenerateThumbnailAsync logs errors, and it calls DownloadAsync which also logs
+		// So we expect at least 1 log call containing the blob URL
+		logger.Received().Log(
+			LogLevel.Error,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(blobUrl)),
+			Arg.Any<Exception>(),
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests/BlobStorageServiceUploadTests.cs
+++ b/tests/Persistence.AzureStorage.Tests/BlobStorageServiceUploadTests.cs
@@ -1,0 +1,189 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageServiceUploadTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests;
+
+/// <summary>
+///   Unit tests for BlobStorageService upload operations.
+/// </summary>
+public sealed class BlobStorageServiceUploadTests
+{
+	[Fact]
+	public async Task UploadAsync_WhenSuccessful_ShouldReturnBlobUrl()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var mockContainerClient = Substitute.For<BlobContainerClient>();
+		var mockBlobClient = Substitute.For<BlobClient>();
+		var expectedUri = new Uri("https://storage.example.com/container/blob-guid/test.txt");
+
+		mockBlobServiceClient.GetBlobContainerClient(Arg.Any<string>()).Returns(mockContainerClient);
+		mockContainerClient.GetBlobClient(Arg.Any<string>()).Returns(mockBlobClient);
+		mockBlobClient.Uri.Returns(expectedUri);
+
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		using var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("test content"));
+		var fileName = "test.txt";
+		var contentType = "text/plain";
+
+		// Act
+		var result = await service.UploadAsync(content, fileName, contentType);
+
+		// Assert
+		result.Should().Be(expectedUri.ToString());
+		result.Should().Contain(fileName);
+	}
+
+	[Fact]
+	public async Task UploadAsync_ShouldCreateContainerIfNotExists()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var mockContainerClient = Substitute.For<BlobContainerClient>();
+		var mockBlobClient = Substitute.For<BlobClient>();
+
+		mockBlobServiceClient.GetBlobContainerClient(Arg.Any<string>()).Returns(mockContainerClient);
+		mockContainerClient.GetBlobClient(Arg.Any<string>()).Returns(mockBlobClient);
+		mockBlobClient.Uri.Returns(new Uri("https://storage.example.com/container/blob"));
+
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		using var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("test content"));
+
+		// Act
+		await service.UploadAsync(content, "test.txt", "text/plain");
+
+		// Assert
+		await mockContainerClient.Received(1).CreateIfNotExistsAsync(
+			PublicAccessType.None,
+			cancellationToken: Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task UploadAsync_ShouldSetCorrectContentTypeHeader()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var mockContainerClient = Substitute.For<BlobContainerClient>();
+		var mockBlobClient = Substitute.For<BlobClient>();
+
+		mockBlobServiceClient.GetBlobContainerClient(Arg.Any<string>()).Returns(mockContainerClient);
+		mockContainerClient.GetBlobClient(Arg.Any<string>()).Returns(mockBlobClient);
+		mockBlobClient.Uri.Returns(new Uri("https://storage.example.com/container/blob"));
+
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		using var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("test content"));
+		var contentType = "application/pdf";
+
+		// Act
+		await service.UploadAsync(content, "test.pdf", contentType);
+
+		// Assert
+		await mockBlobClient.Received(1).UploadAsync(
+			Arg.Any<Stream>(),
+			Arg.Is<BlobUploadOptions>(opts => opts.HttpHeaders.ContentType == contentType),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task UploadAsync_ShouldLogSuccessfulUpload()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var mockContainerClient = Substitute.For<BlobContainerClient>();
+		var mockBlobClient = Substitute.For<BlobClient>();
+
+		mockBlobServiceClient.GetBlobContainerClient(Arg.Any<string>()).Returns(mockContainerClient);
+		mockContainerClient.GetBlobClient(Arg.Any<string>()).Returns(mockBlobClient);
+		mockBlobClient.Uri.Returns(new Uri("https://storage.example.com/container/blob"));
+
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		using var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("test content"));
+		var fileName = "test.txt";
+
+		// Act
+		await service.UploadAsync(content, fileName, "text/plain");
+
+		// Assert
+		logger.Received(1).Log(
+			LogLevel.Information,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(fileName)),
+			null,
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+
+	[Fact]
+	public async Task UploadAsync_WhenExceptionOccurs_ShouldLogErrorAndRethrow()
+	{
+		// Arrange
+		var mockBlobServiceClient = Substitute.For<BlobServiceClient>();
+		var mockContainerClient = Substitute.For<BlobContainerClient>();
+		var mockBlobClient = Substitute.For<BlobClient>();
+
+		mockBlobServiceClient.GetBlobContainerClient(Arg.Any<string>()).Returns(mockContainerClient);
+		mockContainerClient.GetBlobClient(Arg.Any<string>()).Returns(mockBlobClient);
+
+		// Make UploadAsync throw an exception
+		mockBlobClient.UploadAsync(
+				Arg.Any<Stream>(),
+				Arg.Any<BlobUploadOptions>(),
+				Arg.Any<CancellationToken>())
+			.Returns(Task.FromException<Azure.Response<BlobContentInfo>>(new InvalidOperationException("Storage error")));
+
+		mockBlobClient.Uri.Returns(new Uri("https://storage.example.com/container/blob"));
+
+		var settings = Options.Create(new BlobStorageSettings
+		{
+			ContainerName = "test-container"
+		});
+		var logger = Substitute.For<ILogger<BlobStorageService>>();
+		var service = new BlobStorageService(mockBlobServiceClient, settings, logger);
+
+		using var content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("test content"));
+		var fileName = "test.txt";
+
+		// Act
+		Func<Task> act = async () => await service.UploadAsync(content, fileName, "text/plain");
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("Storage error");
+
+		logger.Received(1).Log(
+			LogLevel.Error,
+			Arg.Any<EventId>(),
+			Arg.Is<object>(o => o.ToString()!.Contains(fileName)),
+			Arg.Any<Exception>(),
+			Arg.Any<Func<object, Exception?, string>>());
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests/BlobStorageSettingsTests.cs
+++ b/tests/Persistence.AzureStorage.Tests/BlobStorageSettingsTests.cs
@@ -1,0 +1,98 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     BlobStorageSettingsTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests;
+
+/// <summary>
+///   Unit tests for BlobStorageSettings configuration class.
+/// </summary>
+public sealed class BlobStorageSettingsTests
+{
+	[Fact]
+	public void SectionName_ShouldBeBlobStorage()
+	{
+		// Arrange & Act
+		var sectionName = BlobStorageSettings.SECTION_NAME;
+
+		// Assert
+		sectionName.Should().Be("BlobStorage");
+	}
+
+	[Fact]
+	public void ConnectionString_ShouldDefaultToEmptyString()
+	{
+		// Arrange & Act
+		var settings = new BlobStorageSettings();
+
+		// Assert
+		settings.ConnectionString.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ContainerName_ShouldDefaultToIssueAttachments()
+	{
+		// Arrange & Act
+		var settings = new BlobStorageSettings();
+
+		// Assert
+		settings.ContainerName.Should().Be("issue-attachments");
+	}
+
+	[Fact]
+	public void ThumbnailContainerName_ShouldDefaultToIssueAttachmentsThumbnails()
+	{
+		// Arrange & Act
+		var settings = new BlobStorageSettings();
+
+		// Assert
+		settings.ThumbnailContainerName.Should().Be("issue-attachments-thumbnails");
+	}
+
+	[Fact]
+	public void ConnectionString_CanBeSetToCustomValue()
+	{
+		// Arrange
+		var settings = new BlobStorageSettings();
+		var customConnectionString = "DefaultEndpointsProtocol=https;AccountName=custom;AccountKey=Y3VzdG9t";
+
+		// Act
+		settings.ConnectionString = customConnectionString;
+
+		// Assert
+		settings.ConnectionString.Should().Be(customConnectionString);
+	}
+
+	[Fact]
+	public void ContainerName_CanBeSetToCustomValue()
+	{
+		// Arrange
+		var settings = new BlobStorageSettings();
+		var customContainerName = "my-custom-container";
+
+		// Act
+		settings.ContainerName = customContainerName;
+
+		// Assert
+		settings.ContainerName.Should().Be(customContainerName);
+	}
+
+	[Fact]
+	public void ThumbnailContainerName_CanBeSetToCustomValue()
+	{
+		// Arrange
+		var settings = new BlobStorageSettings();
+		var customThumbnailName = "my-custom-thumbnails";
+
+		// Act
+		settings.ThumbnailContainerName = customThumbnailName;
+
+		// Assert
+		settings.ThumbnailContainerName.Should().Be(customThumbnailName);
+	}
+}

--- a/tests/Persistence.AzureStorage.Tests/GlobalUsings.cs
+++ b/tests/Persistence.AzureStorage.Tests/GlobalUsings.cs
@@ -1,0 +1,36 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     GlobalUsings.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+// Testing
+// System
+global using System;
+global using System.IO;
+global using System.Threading;
+global using System.Threading.Tasks;
+// Azure Storage
+global using Azure.Storage.Blobs;
+global using Azure.Storage.Blobs.Models;
+// Domain
+global using Domain.Abstractions;
+global using Domain.Models;
+
+global using FluentAssertions;
+
+global using Microsoft.Extensions.Configuration;
+global using Microsoft.Extensions.DependencyInjection;
+// Microsoft Extensions
+global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Logging.Abstractions;
+global using Microsoft.Extensions.Options;
+
+global using NSubstitute;
+// Project Under Test
+global using Persistence.AzureStorage;
+
+global using Xunit;

--- a/tests/Persistence.AzureStorage.Tests/Persistence.AzureStorage.Tests.csproj
+++ b/tests/Persistence.AzureStorage.Tests/Persistence.AzureStorage.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="NSubstitute" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Options" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<PackageReference Include="Azure.Storage.Blobs" />
+		<PackageReference Include="coverlet.collector">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Persistence.AzureStorage\Persistence.AzureStorage.csproj" />
+	</ItemGroup>
+</Project>

--- a/tests/Persistence.AzureStorage.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Persistence.AzureStorage.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,204 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     ServiceCollectionExtensionsTests.cs
+// Company :       mpaulosky
+// Author :        Matthew Paulosky
+// Solution Name : IssueTrackerApp
+// Project Name :  Persistence.AzureStorage.Tests
+// =======================================================
+
+namespace Persistence.AzureStorage.Tests;
+
+/// <summary>
+///   Unit tests for ServiceCollectionExtensions dependency injection configuration.
+/// </summary>
+public sealed class ServiceCollectionExtensionsTests
+{
+	[Fact]
+	public void AddAzureBlobStorage_WithValidConnectionString_ShouldRegisterBlobServiceClientAsSingleton()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ConnectionString"] = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==;EndpointSuffix=core.windows.net",
+				["BlobStorage:ContainerName"] = "my-container",
+				["BlobStorage:ThumbnailContainerName"] = "my-thumbnails"
+			})
+			.Build();
+
+		// Act
+		services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		var serviceProvider = services.BuildServiceProvider();
+		var blobServiceClient = serviceProvider.GetService<BlobServiceClient>();
+		blobServiceClient.Should().NotBeNull();
+
+		// Verify singleton by getting service twice
+		var blobServiceClient2 = serviceProvider.GetService<BlobServiceClient>();
+		blobServiceClient.Should().BeSameAs(blobServiceClient2);
+	}
+
+	[Fact]
+	public void AddAzureBlobStorage_WithValidConnectionString_ShouldRegisterFileStorageServiceAsScoped()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		// Add a logger factory to satisfy BlobStorageService's ILogger dependency
+		services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+		services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ConnectionString"] = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==;EndpointSuffix=core.windows.net",
+				["BlobStorage:ContainerName"] = "my-container"
+			})
+			.Build();
+
+		// Act
+		services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		var serviceProvider = services.BuildServiceProvider();
+		using var scope = serviceProvider.CreateScope();
+		var fileStorageService = scope.ServiceProvider.GetService<IFileStorageService>();
+		fileStorageService.Should().NotBeNull();
+		fileStorageService.Should().BeOfType<BlobStorageService>();
+	}
+
+	[Fact]
+	public void AddAzureBlobStorage_ShouldConfigureBlobStorageSettingsFromConfiguration()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ConnectionString"] = "DefaultEndpointsProtocol=https;AccountName=custom;AccountKey=Y3VzdG9t;EndpointSuffix=core.windows.net",
+				["BlobStorage:ContainerName"] = "custom-container",
+				["BlobStorage:ThumbnailContainerName"] = "custom-thumbnails"
+			})
+			.Build();
+
+		// Act
+		services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		var serviceProvider = services.BuildServiceProvider();
+		var settings = serviceProvider.GetService<IOptions<BlobStorageSettings>>();
+		settings.Should().NotBeNull();
+		settings!.Value.ConnectionString.Should().Be("DefaultEndpointsProtocol=https;AccountName=custom;AccountKey=Y3VzdG9t;EndpointSuffix=core.windows.net");
+		settings.Value.ContainerName.Should().Be("custom-container");
+		settings.Value.ThumbnailContainerName.Should().Be("custom-thumbnails");
+	}
+
+	[Fact]
+	public void AddAzureBlobStorage_WithEmptyConnectionString_ShouldNotRegisterBlobServiceClient()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ConnectionString"] = "",
+				["BlobStorage:ContainerName"] = "my-container"
+			})
+			.Build();
+
+		// Act
+		services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		var serviceProvider = services.BuildServiceProvider();
+		var blobServiceClient = serviceProvider.GetService<BlobServiceClient>();
+		blobServiceClient.Should().BeNull();
+	}
+
+	[Fact]
+	public void AddAzureBlobStorage_WithEmptyConnectionString_ShouldNotRegisterFileStorageService()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ConnectionString"] = "",
+				["BlobStorage:ContainerName"] = "my-container"
+			})
+			.Build();
+
+		// Act
+		services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		var serviceProvider = services.BuildServiceProvider();
+		var fileStorageService = serviceProvider.GetService<IFileStorageService>();
+		fileStorageService.Should().BeNull();
+	}
+
+	[Fact]
+	public void AddAzureBlobStorage_WithNullConnectionString_ShouldNotRegisterBlobServiceClient()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ContainerName"] = "my-container"
+				// ConnectionString intentionally omitted (null)
+			})
+			.Build();
+
+		// Act
+		services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		var serviceProvider = services.BuildServiceProvider();
+		var blobServiceClient = serviceProvider.GetService<BlobServiceClient>();
+		blobServiceClient.Should().BeNull();
+	}
+
+	[Fact]
+	public void AddAzureBlobStorage_WithNullConnectionString_ShouldNotRegisterFileStorageService()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ContainerName"] = "my-container"
+				// ConnectionString intentionally omitted (null)
+			})
+			.Build();
+
+		// Act
+		services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		var serviceProvider = services.BuildServiceProvider();
+		var fileStorageService = serviceProvider.GetService<IFileStorageService>();
+		fileStorageService.Should().BeNull();
+	}
+
+	[Fact]
+	public void AddAzureBlobStorage_ShouldReturnServiceCollection()
+	{
+		// Arrange
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["BlobStorage:ConnectionString"] = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==;EndpointSuffix=core.windows.net"
+			})
+			.Build();
+
+		// Act
+		var result = services.AddAzureBlobStorage(configuration);
+
+		// Assert
+		result.Should().BeSameAs(services);
+	}
+}


### PR DESCRIPTION
## Summary

Ports the Azure Blob Storage implementation and test suites from `main` to `dev`.

## Why

- `main` has `src/Persistence.AzureStorage` + test projects added after the last dev→main sync
- `dev` is missing these files
- `squad-preview.yml` already references `tests/Persistence.AzureStorage.Tests[.Integration]` → CI fails with MSB1009
- PR #303 (`dev`→`main`) would **delete** these projects from `main` if merged without this fix

## Changes
- Adds `src/Persistence.AzureStorage/` source project
- Adds `tests/Persistence.AzureStorage.Tests/` unit tests (33 tests passing)
- Adds `tests/Persistence.AzureStorage.Tests.Integration/` integration tests
- Updates `IssueTrackerApp.slnx` with the 3 new project entries
- Adds `Azure.Storage.Blobs` v12.20.0 to `Directory.Packages.props`

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Prerequisite for
Resolves CI failures on `dev` and unblocks PR #303 (release to main)

## Testing
- ✅ Build succeeded (all 17 projects compiled)
- ✅ Unit tests passed (33/33 tests in Persistence.AzureStorage.Tests)
- ℹ️ Integration tests require Azurite/Docker (not run locally)